### PR TITLE
Moving Notify content to prototype

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -330,7 +330,7 @@
                     <a href="/interested-party/v2/comment-received" class="govuk-link--no-visited-state">Confirmation</a>
                   </li>
                   <li>
-                    <a href="https://www.notifications.service.gov.uk/services/c46d894e-d10e-4c46-a467-019576cd906a/templates/7e4ae1c2-aa2f-4e0d-b79b-fb05918b00dc">Comment received confirmation email</a>
+                    <a href="/interested-party/v2/comments-received-confirmation">Comment received confirmation email</a>
                   </li>
 
                 </ul>

--- a/app/views/interested-party/v2/comments-received-confirmation.html
+++ b/app/views/interested-party/v2/comments-received-confirmation.html
@@ -1,0 +1,66 @@
+{% extends "layout-email.html" %}
+
+{% block pageTitle %}
+  Interested party full planning notification
+{% endblock %}
+
+
+Dear [IP NAME]Site detailsSite Address:[INSERT HERE]Description of development:[INSERT HERE]Application reference:[INSERT HERE]An appeal has been made against the decision of [LPD]to [insert reason for appeal, i.e. refuse to grant planning permission].[The appeal will be determined on the basis of written representations.][The appeal will be determined on the basis of a hearing.] [The appeal will be determined on the basis of an inquiry.] Interested individuals that want to take part in the Inquiry can do so by applying for Rule 6 status.Rule 6 status means that you would be able to present your evidence on a formal basis and cross examine the evidence of others.You can learn more about Rule 6 at:https://www.gov.uk/government/publications/apply-for-rule-6-status-on-a-planning-appeal-or-called-in-applicationWhat happens next** TO BE ADDED **Thank you,The Planning Inspectorate
+
+
+
+{% block content %}
+<p><strong>Subject:</strong> We’ve received your comments for appeal APP/Q999/O/21/1234567</p>
+<p><strong>From:</strong> planningappeals@bristolcitycouncil.gov.uk</p>
+
+<!-- <img src="{{ asset_path }}images/pi-logo.png" width="150"/> -->
+
+<hr>
+
+<div class="govuk-grid-row govuk-!-margin-top-5">
+  <div class="govuk-grid-column-two-thirds">
+
+    <!-- <p class="govuk-body">Planning appeal reference: A/1234567</p> -->
+    <p class="govuk-body">Dear [name],</p>
+    <!-- <p class="govuk-body">We’ve started a full appeal against the refusal of planning application <strong>A/10112454</strong>.</p> -->
+
+    <p class="govuk-body">
+      Your comments have been received.
+    </p>
+
+    <p class="govuk-body">
+      <strong>Appeal reference:</strong><br>
+      APP/Q999/O/21/1234567
+    </p>
+
+    <p class="govuk-body">
+      <strong>Appeal site:</strong><br>
+      1 Aubrey House
+      Aubrey Road
+      Bristol BS3 3EX
+    </p>
+
+    <h2 class="govuk-heading-m">
+      What happens next
+    </h2>
+
+    <p class="govuk-body">
+      Your comments will be shared with the applicant and local planning department.
+    </p>
+
+    <p class="govuk-body">
+      An Inspector will review them when determining the appeal.
+    </p>
+
+    <p class="govuk-body">
+      When a decision is made, it will be published online at <a href="https://www.bristol.gov.uk/planning-and-building-regulations/search-and-track-planning-applications">https://www.bristol.gov.uk/planning-and-building-regulations/search-and-track-planning-applications</a>
+    </p>
+
+    <p class="govuk-body">
+      From,​<br>
+      Bristol City Council Planning Department<br>
+    </p>
+
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Moving the Notify confirmation email to the prototype so that UR doesn’t have to sign into Notify.