### PR TITLE
Link to LDP and small format updates

### DIFF
--- a/app/views/interested-party/v3/appeal-details.html
+++ b/app/views/interested-party/v3/appeal-details.html
@@ -47,7 +47,7 @@
 
     <div class="govuk-grid-column-full">
       {% if data['status'] == "open" %}
-
+        <!-- comments are open -->
         <section class="govuk-!-margin-bottom-3">
           <strong class="govuk-tag govuk-tag--green">
             Open for comments
@@ -176,6 +176,17 @@
         {% endif %}
 
       </dl>
+
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+
+      <p class="govuk-body">
+        <a href="#">
+          View the application details on the local planning department’s website (opens in new tab)
+        </a>
+      </p>
+
 
       {% if data['status'] == "open" %}
 

--- a/app/views/interested-party/v3/check-answers.html
+++ b/app/views/interested-party/v3/check-answers.html
@@ -72,11 +72,17 @@
             Comments
           </dt>
           <dd class="govuk-summary-list__value">
-            {% set i = 0 %}
-            {% for file in data['comments'] %}
-              {% set i = i + 1 %}
-              <p class="govuk-body">{{ file }}</p>
-            {% endfor %}
+            <p class="govuk-body">
+              {% if data['comments'] %}
+                {% set i = 0 %}
+                {% for file in data['comments'] %}
+                  {% set i = i + 1 %}
+                    {{ file }}<br>
+                {% endfor %}
+              {% else %}
+                Appeal comments.txt
+              {% endif %}
+            </p>
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="comment-upload?checking=1">
@@ -85,6 +91,9 @@
           </dd>
         </div>
       </dl>
+
+    </div>
+    <div class="govuk-grid-column-two-thirds">
 
       <h2 class="govuk-heading-m">
         Now send your comments

--- a/app/views/interested-party/v3/comments-received-confirmation.html
+++ b/app/views/interested-party/v3/comments-received-confirmation.html
@@ -30,7 +30,7 @@ Dear [IP NAME]Site detailsSite Address:[INSERT HERE]Description of development:[
 
     <p class="govuk-body">
       <strong>Appeal reference:</strong><br>
-      APP/Q999/O/21/0166327
+      0166327
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
Adding a link to local planning department on the appeal details screen.

Some small format updates and fallback for uploaded comments file name on the check answers screen.