### PR TITLE
Save progress logic fix for continue link in temp email and inbox tweaks

### DIFF
--- a/app/assets/sass/pins/email.scss
+++ b/app/assets/sass/pins/email.scss
@@ -2,29 +2,39 @@
   font-size: 16px;
 }
 
-.email-inbox .govuk-table__header {
-  padding-left: 10px;
-}
-
 .email-inbox td {
   padding: 0;
 }
 
 .email-unread td {
   font-weight: bold;
+  padding: 10px 0;
 }
 
 .email-read td {
   background: #f5f5f5;
-  padding: 10px;
+  padding: 10px 0;
 }
 
 .email-inbox a:link {
-  padding: 10px;
   color: $govuk-text-colour;
   display: inline-block;
   text-decoration: none;
   width: 100%;
+}
+
+.email-inbox a:hover {
+  text-decoration: underline;
+}
+
+.email-inbox a:focus {
+  // removes the gds focus styles
+  background-color: white !important;
+  border: none !important;
+  box-shadow: none !important;
+
+  // simple link
+  text-decoration: underline;
 }
 
 .email-inbox a:visited {

--- a/app/routes/save-progress/v2/v2.js
+++ b/app/routes/save-progress/v2/v2.js
@@ -3,24 +3,21 @@ module.exports = function (router) {
   var v = "v2";
   var base = "/save-progress/"+v;
 
+  // route for completing the contact details task
   router.post(base+'/contact-details/your-details', function (req, res) {
     req.session.data["contactdetails-"+v+"-taskliststatus-contactdetails"] = "Complete";
     res.redirect(base+'/task-list');
-    // data["appealsub-"+version+"-taskliststatus-contactdetails"]
   })
 
+  // route for service start
   router.post(base+'/what-do-you-want-to-do', function (req, res) {
-
     let choice = req.session.data['new-or-continue']
-
-
     // route depending on value
     if (choice === 'new') {
       res.redirect('/appellant-submission/v13/')
     } else {
       res.redirect('input-magic-link-email')
     }
-
   })
 
 }

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -145,13 +145,19 @@
                         </a>
                       </li>
                       <li>
-                        <a href="/incomplete-appeals">
+                        <a href="/save-progress/v2/incomplete-appeals">
                           Incomplete appeals
                         </a>
                       </li>
                       <li>
-                        <a href="/return-email">
+                        <a href="/save-progress/v2/return-email">
                           Return email
+                        </a>
+                      </li>
+                      <br>
+                      <li>
+                        <a href="/save-progress/v2/what-do-you-want-to-do">
+                          Service start
                         </a>
                       </li>
 

--- a/app/views/save-progress/v2/incomplete-appeals.html
+++ b/app/views/save-progress/v2/incomplete-appeals.html
@@ -93,7 +93,11 @@
       </tbody>
     </table>
 
-
+    {{ govukButton({
+      href: "appeal-saved?savedOn=appeals",
+      text: "Save and come back later",
+      classes: "govuk-button--secondary"
+    }) }}
 
   </div>
 </div>

--- a/app/views/save-progress/v2/input-magic-link-email.html
+++ b/app/views/save-progress/v2/input-magic-link-email.html
@@ -49,12 +49,7 @@
         }) }}
 
       </form>
-<!--
-      <p class="govuk-body">
-        <a href="appeal-start">
-          Start a new planning appeal
-        </a>
-      </p> -->
+
 
     </div>
   </div>

--- a/app/views/save-progress/v2/magic-link-email-sent.html
+++ b/app/views/save-progress/v2/magic-link-email-sent.html
@@ -38,7 +38,7 @@
 
       <p class="govuk-body">
         We’ve emailed a link to:<br>
-        admin@wedoplanningappeals.co.uk
+        {{ data['email'] or 'sam@mac.com'}}
       </p>
 
       <p class="govuk-body">

--- a/app/views/save-progress/v2/magic-link-email.html
+++ b/app/views/save-progress/v2/magic-link-email.html
@@ -30,13 +30,19 @@ Dear [IP NAME]Site detailsSite Address:[INSERT HERE]Description of development:[
 <div class="govuk-grid-row govuk-!-margin-top-5">
   <div class="govuk-grid-column-two-thirds">
 
+    <p class="govuk-body">
+      {{ data['savedOn'] }}
+    </p>
+
     <p class="govuk-body">Dear [name],</p>
 
     <p class="govuk-body">
       Go to the link to continue with your appeal submission:<br>
 
-      {% if data['savedOn'] === 'start' %}
+      {% if data['savedOn'] == 'start' %}
         <a href="before-you-continue">www.gov.uk/appeal-a-planning-decision/appeals?session=679aa0</a>
+      {% elseif data['savedOn'] == 'task' %}
+        <a href="task-list">www.gov.uk/appeal-a-planning-decision/appeals?session=679aa0</a>
       {% else %}
           <a href="incomplete-appeals">www.gov.uk/appeal-a-planning-decision/appeals?session=321fa2</a>
       {% endif %}


### PR DESCRIPTION
Save progress, the magic link takes you back to the right place.

Also, small updates to the generic inbox UI to remove some of the GDS (yellow focus) styles.