### PR TITLE
Sensitive info, back-pedal for public guidance

### DIFF
--- a/app/views/guidance/full/v2/your-appeal-statement.html
+++ b/app/views/guidance/full/v2/your-appeal-statement.html
@@ -156,14 +156,20 @@
         </h3>
 
         <p class="govuk-body">
-          You should avoid including sensitive information (also called special category information) if it’s not relevant to the appeal. Any sensitive information you share may be shared publicly if the Planning Inspector agrees that it’s relevant to your appeal.
+          Avoid including sensitive information (also called special category information) if it’s not relevant to your appeal. Any sensitive information you share may be shared publicly if the Planning Inspectorate agrees that it’s relevant to your appeal.
         </p>
 
-        <p>
+        <p class="govuk-body">
+          Sensitive information includes health, race and gender.
+        </p>
+
+        <h3 class="govuk-heading-l pins-guidance-h3">
+          Inflammatory and abusive language
+        </h3>
+
+        <p class="govuk-body">
           You must not include inflammatory or abusive language.
         </p>
-
-        {% include "includes/sensitive-info-list.html" %}
 
         <!-- Navigation-->
         <nav class="gem-c-pagination govuk-!-margin-top-9" role="navigation" aria-label="Pagination">


### PR DESCRIPTION
We didn’t need to update the public guidance content about sensitive information. I have back-pedalled this change here.