### PR TITLE
Email confirmed, remove back button

### DIFF
--- a/app/views/save-progress/v3/email-confirmed.html
+++ b/app/views/save-progress/v3/email-confirmed.html
@@ -17,10 +17,6 @@
     html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
   }) }}
 
-  {{ govukBackLink({
-    text: "Back",
-    href: "javascript:history.go(-1);"
-  }) }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
The email confirmed screen shouldn’t have a back button.