### PR TITLE
Update to logic for grounds/reasons

### DIFF
--- a/app/routes/enforcement/v1.js
+++ b/app/routes/enforcement/v1.js
@@ -147,19 +147,19 @@ module.exports = function (router) {
 
     // route depending on value
     if (groundA) {
-      res.redirect('/enforcement/v1/grounds/groundA-text')
+      res.redirect('/enforcement/v1/grounds/groundA')
     } else if (groundB) {
-      res.redirect('/enforcement/v1/grounds/groundB-text')
+      res.redirect('/enforcement/v1/grounds/groundB')
     } else if (groundC) {
-      res.redirect('/enforcement/v1/grounds/groundC-text')
+      res.redirect('/enforcement/v1/grounds/groundC')
     } else if (groundD) {
-      res.redirect('/enforcement/v1/grounds/groundD-text')
+      res.redirect('/enforcement/v1/grounds/groundD')
     } else if (groundE) {
-      res.redirect('/enforcement/v1/grounds/groundE-text')
+      res.redirect('/enforcement/v1/grounds/groundE')
     } else if (groundF) {
-      res.redirect('/enforcement/v1/grounds/groundF-text')
+      res.redirect('/enforcement/v1/grounds/groundF')
     } else {
-      res.redirect('/enforcement/v1/grounds/groundG-text')
+      res.redirect('/enforcement/v1/grounds/groundG')
     }
   })
 

--- a/app/views/enforcement/v1/grounds/groundA-file.html
+++ b/app/views/enforcement/v1/grounds/groundA-file.html
@@ -31,7 +31,9 @@
     <form action="" method="post">
 
       <div class="govuk-form-group">
-        <label class="govuk-label govuk-label--l" for="caseofficer-{{version}}-update-otherpolicies">
+
+        <!-- reasons by file -->
+        <label class="govuk-label govuk-label--l" for="enforcement-ground-b-reasons">
           {{ title  }}
         </label>
         <p class="govuk-hint">
@@ -39,7 +41,7 @@
         <p>
 
         <!-- upload files -->
-        <label class="govuk-label govuk-label--m" for="appealsub-{{version}}-appealdocuments-plansdrawings-files">
+        <label class="govuk-label govuk-label--m" for="enforcement-ground-b-reasons">
           Drag and drop or choose files
         </label>
         <input class="govuk-file-upload pins-file-upload" id="enforcement-ground-a-reasons" name="enforcement-ground-a-reasons" type="file" multiple>

--- a/app/views/enforcement/v1/grounds/groundA.html
+++ b/app/views/enforcement/v1/grounds/groundA.html
@@ -1,0 +1,149 @@
+{% extends "layouts/appellant-submission/v11.html" %}
+
+{% set title = "Tell us why you think the supposed breach of planning control should be allowed" %}
+
+{% block pageTitle %}
+  {{title}} - Tell us about the appeal site - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">
+      Choose your grounds of appeal
+    </span>
+
+    <form action="" method="post">
+
+      <div class="govuk-form-group">
+
+        {% if data['enforcement-reason-method'] == 'text' %}
+
+          <!-- reasons by multitext input -->
+          {{ govukTextarea({
+            name: "enforcement-ground-a-reasons",
+            id: "enforcement-ground-a-reasons",
+            label: {
+              text: title,
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            hint: {
+              text: "You do not need to repeat the local planning department’s reasons for issuing the enforcement notice."
+            }
+          }) }}
+
+          <p class="govuk-body">
+            <a href="groundA?enforcement-reason-method=file" class="govuk-link">
+              Upload your reasons in a document
+            </a>
+          </p>
+
+        {% else %}
+
+          <!-- reasons by file -->
+          <label class="govuk-label govuk-label--l" for="enforcement-ground-a-reasons">
+            {{ title  }}
+          </label>
+          <p class="govuk-hint">
+            You do not need to repeat the local planning department’s reasons for issuing the enforcement notice.
+          <p>
+
+          <!-- upload files -->
+          <label class="govuk-label govuk-label--m" for="enforcement-ground-a-reasons">
+            Drag and drop or choose files
+          </label>
+          <input class="govuk-file-upload pins-file-upload" id="enforcement-ground-a-reasons" name="enforcement-ground-a-reasons" type="file" multiple>
+
+        </div>
+
+        {{ govukInsetText({
+          text: "File size should be no more than 15MB"
+        }) }}
+
+        {{ govukDetails({
+          summaryText: "Help with file formats",
+          html: '
+            <p class="govuk-body">
+              Your file must be in one of the following formats:
+            <p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>pdf</li>
+              <li>doc</li>
+              <li>docx</li>
+              <li>tif</li>
+              <li>tiff</li>
+              <li>jpg</li>
+              <li>jpeg</li>
+              <li>png</li>
+            </ul>
+          '
+        }) }}
+
+        <p class="govuk-body">
+          <a href="groundA?enforcement-reason-method=text" class="govuk-link">
+            Explain your reasons using a text box
+          </a>
+        </p>
+
+      {% endif %}
+
+      <!-- route user based on what they selected -->
+      {% if data['grounds-2'] %}
+        {{ govukButton({
+          href: "groundB",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-3'] %}
+        {{ govukButton({
+          href: "groundC",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-4'] %}
+        {{ govukButton({
+          href: "groundD",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-5'] %}
+        {{ govukButton({
+          href: "groundE",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-6'] %}
+        {{ govukButton({
+          href: "groundF",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-7'] %}
+        {{ govukButton({
+          href: "groundG",
+          text: "Continue"
+        }) }}
+      {% else %}
+        {{ govukButton({
+          href: "application",
+          text: "Continue"
+        }) }}
+      {% endif %}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/enforcement/v1/grounds/groundB-file.html
+++ b/app/views/enforcement/v1/grounds/groundB-file.html
@@ -30,7 +30,7 @@
       <form action="" method="post">
 
         <div class="govuk-form-group">
-          <label class="govuk-label govuk-label--l" for="caseofficer-{{version}}-update-otherpolicies">
+          <label class="govuk-label govuk-label--l" for="enforcement-ground-b-reasons">
             {{ title  }}
           </label>
           <p class="govuk-hint">
@@ -38,10 +38,11 @@
           <p>
 
           <!-- upload files -->
-          <label class="govuk-label govuk-label--m" for="appealsub-{{version}}-appealdocuments-plansdrawings-files">
+          <label class="govuk-label govuk-label--m" for="enforcement-ground-b-reasons">
             Drag and drop or choose files
           </label>
-          <input class="govuk-file-upload pins-file-upload" id="enforcement-ground-b-reasons" name="enforcement-ground-a-reasons" type="file" multiple>
+
+          <input class="govuk-file-upload pins-file-upload" id="enforcement-ground-b-reasons" name="enforcement-ground-b-reasons" type="file" multiple>
 
         </div>
 

--- a/app/views/enforcement/v1/grounds/groundB.html
+++ b/app/views/enforcement/v1/grounds/groundB.html
@@ -1,0 +1,144 @@
+{% extends "layouts/appellant-submission/v11.html" %}
+
+{% set title = "Tell is how the supposed breach of planning control never happened, or is not being used in the way that the local planning department says it is" %}
+
+{% block pageTitle %}
+  {{title}} - Tell us about the appeal site - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">
+      Choose your grounds of appeal
+    </span>
+
+    <form action="" method="post">
+
+      <div class="govuk-form-group">
+
+        {% if data['enforcement-reason-method'] == 'text' %}
+
+          <!-- reasons by multitext input -->
+          {{ govukTextarea({
+            name: "enforcement-ground-b-reasons",
+            id: "enforcement-ground-b-reasons",
+            label: {
+              text: title,
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            hint: {
+              text: "You do not need to repeat the local planning department’s reasons for issuing the enforcement notice."
+            }
+          }) }}
+
+          <p class="govuk-body">
+            <a href="groundB?enforcement-reason-method=file" class="govuk-link">
+              Upload your reasons in a document
+            </a>
+          </p>
+
+        {% else %}
+
+          <!-- reasons by file -->
+          <label class="govuk-label govuk-label--l" for="enforcement-ground-b-reasons">
+            {{ title  }}
+          </label>
+          <p class="govuk-hint">
+            You do not need to repeat the local planning department’s reasons for issuing the enforcement notice.
+          <p>
+
+          <!-- upload files -->
+          <label class="govuk-label govuk-label--m" for="enforcement-ground-b-reasons">
+            Drag and drop or choose files
+          </label>
+          <input class="govuk-file-upload pins-file-upload" id="enforcement-ground-b-reasons" name="enforcement-ground-b-reasons" type="file" multiple>
+
+        </div>
+
+        {{ govukInsetText({
+          text: "File size should be no more than 15MB"
+        }) }}
+
+        {{ govukDetails({
+          summaryText: "Help with file formats",
+          html: '
+            <p class="govuk-body">
+              Your file must be in one of the following formats:
+            <p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>pdf</li>
+              <li>doc</li>
+              <li>docx</li>
+              <li>tif</li>
+              <li>tiff</li>
+              <li>jpg</li>
+              <li>jpeg</li>
+              <li>png</li>
+            </ul>
+          '
+        }) }}
+
+        <p class="govuk-body">
+          <a href="groundB?enforcement-reason-method=text" class="govuk-link">
+            Explain your reasons using a text box
+          </a>
+        </p>
+
+      {% endif %}
+
+      <!-- route user based on what they selected -->
+      {% if data['grounds-3'] %}
+        {{ govukButton({
+          href: "groundC",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-4'] %}
+        {{ govukButton({
+          href: "groundD",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-5'] %}
+        {{ govukButton({
+          href: "groundE",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-6'] %}
+        {{ govukButton({
+          href: "groundF",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-7'] %}
+        {{ govukButton({
+          href: "groundG",
+          text: "Continue"
+        }) }}
+      {% else %}
+        {{ govukButton({
+          href: "application",
+          text: "Continue"
+        }) }}
+      {% endif %}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/enforcement/v1/grounds/groundC.html
+++ b/app/views/enforcement/v1/grounds/groundC.html
@@ -1,0 +1,139 @@
+{% extends "layouts/appellant-submission/v11.html" %}
+
+{% set title = "Tell us why the supposed breach of planning control does not need planning permission" %}
+
+{% block pageTitle %}
+  {{title}} - Tell us about the appeal site - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">
+      Choose your grounds of appeal
+    </span>
+
+    <form action="" method="post">
+
+      <div class="govuk-form-group">
+
+        {% if data['enforcement-reason-method'] == 'text' %}
+
+          <!-- reasons by multitext input -->
+          {{ govukTextarea({
+            name: "enforcement-ground-c-reasons",
+            id: "enforcement-ground-c-reasons",
+            label: {
+              text: title,
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            hint: {
+              text: "You do not need to repeat the local planning department’s reasons for issuing the enforcement notice."
+            }
+          }) }}
+
+          <p class="govuk-body">
+            <a href="groundC?enforcement-reason-method=file" class="govuk-link">
+              Upload your reasons in a document
+            </a>
+          </p>
+
+        {% else %}
+
+          <!-- reasons by file -->
+          <label class="govuk-label govuk-label--l" for="enforcement-ground-c-reasons">
+            {{ title  }}
+          </label>
+          <p class="govuk-hint">
+            You do not need to repeat the local planning department’s reasons for issuing the enforcement notice.
+          <p>
+
+          <!-- upload files -->
+          <label class="govuk-label govuk-label--m" for="enforcement-ground-c-reasons">
+            Drag and drop or choose files
+          </label>
+          <input class="govuk-file-upload pins-file-upload" id="enforcement-ground-c-reasons" name="enforcement-ground-c-reasons" type="file" multiple>
+
+        </div>
+
+        {{ govukInsetText({
+          text: "File size should be no more than 15MB"
+        }) }}
+
+        {{ govukDetails({
+          summaryText: "Help with file formats",
+          html: '
+            <p class="govuk-body">
+              Your file must be in one of the following formats:
+            <p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>pdf</li>
+              <li>doc</li>
+              <li>docx</li>
+              <li>tif</li>
+              <li>tiff</li>
+              <li>jpg</li>
+              <li>jpeg</li>
+              <li>png</li>
+            </ul>
+          '
+        }) }}
+
+        <p class="govuk-body">
+          <a href="groundC?enforcement-reason-method=text" class="govuk-link">
+            Explain your reasons using a text box
+          </a>
+        </p>
+
+      {% endif %}
+
+      <!-- route user based on what they selected -->
+      {% if data['grounds-4'] %}
+        {{ govukButton({
+          href: "groundD",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-5'] %}
+        {{ govukButton({
+          href: "groundE",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-6'] %}
+        {{ govukButton({
+          href: "groundF",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-7'] %}
+        {{ govukButton({
+          href: "groundG",
+          text: "Continue"
+        }) }}
+      {% else %}
+        {{ govukButton({
+          href: "application",
+          text: "Continue"
+        }) }}
+      {% endif %}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/enforcement/v1/grounds/groundD.html
+++ b/app/views/enforcement/v1/grounds/groundD.html
@@ -1,0 +1,134 @@
+{% extends "layouts/appellant-submission/v11.html" %}
+
+{% set title = "Tell us why you think the local planning department missed its deadline to take action" %}
+
+{% block pageTitle %}
+  {{title}} - Tell us about the appeal site - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">
+      Choose your grounds of appeal
+    </span>
+
+    <form action="" method="post">
+
+      <div class="govuk-form-group">
+
+        {% if data['enforcement-reason-method'] == 'text' %}
+
+          <!-- reasons by multitext input -->
+          {{ govukTextarea({
+            name: "enforcement-ground-d-reasons",
+            id: "enforcement-ground-d-reasons",
+            label: {
+              text: title,
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            hint: {
+              text: "You do not need to repeat the local planning department’s reasons for issuing the enforcement notice."
+            }
+          }) }}
+
+          <p class="govuk-body">
+            <a href="groundD?enforcement-reason-method=file" class="govuk-link">
+              Upload your reasons in a document
+            </a>
+          </p>
+
+        {% else %}
+
+          <!-- reasons by file -->
+          <label class="govuk-label govuk-label--l" for="enforcement-ground-d-reasons">
+            {{ title  }}
+          </label>
+          <p class="govuk-hint">
+            You do not need to repeat the local planning department’s reasons for issuing the enforcement notice.
+          <p>
+
+          <!-- upload files -->
+          <label class="govuk-label govuk-label--m" for="enforcement-ground-d-reasons">
+            Drag and drop or choose files
+          </label>
+          <input class="govuk-file-upload pins-file-upload" id="enforcement-ground-d-reasons" name="enforcement-ground-d-reasons" type="file" multiple>
+
+        </div>
+
+        {{ govukInsetText({
+          text: "File size should be no more than 15MB"
+        }) }}
+
+        {{ govukDetails({
+          summaryText: "Help with file formats",
+          html: '
+            <p class="govuk-body">
+              Your file must be in one of the following formats:
+            <p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>pdf</li>
+              <li>doc</li>
+              <li>docx</li>
+              <li>tif</li>
+              <li>tiff</li>
+              <li>jpg</li>
+              <li>jpeg</li>
+              <li>png</li>
+            </ul>
+          '
+        }) }}
+
+        <p class="govuk-body">
+          <a href="groundD?enforcement-reason-method=text" class="govuk-link">
+            Explain your reasons using a text box
+          </a>
+        </p>
+
+      {% endif %}
+
+      <!-- route user based on what they selected -->
+      {% if data['grounds-5'] %}
+        {{ govukButton({
+          href: "groundE",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-6'] %}
+        {{ govukButton({
+          href: "groundF",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-7'] %}
+        {{ govukButton({
+          href: "groundG",
+          text: "Continue"
+        }) }}
+      {% else %}
+        {{ govukButton({
+          href: "application",
+          text: "Continue"
+        }) }}
+      {% endif %}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/enforcement/v1/grounds/groundE.html
+++ b/app/views/enforcement/v1/grounds/groundE.html
@@ -1,0 +1,129 @@
+{% extends "layouts/appellant-submission/v11.html" %}
+
+{% set title = "Tell us why you think the local planning department did not serve copies of the enforcement notice as they’re legally required to" %}
+
+{% block pageTitle %}
+  {{title}} - Tell us about the appeal site - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">
+      Choose your grounds of appeal
+    </span>
+
+    <form action="" method="post">
+
+      <div class="govuk-form-group">
+
+        {% if data['enforcement-reason-method'] == 'text' %}
+
+          <!-- reasons by multitext input -->
+          {{ govukTextarea({
+            name: "enforcement-ground-e-reasons",
+            id: "enforcement-ground-e-reasons",
+            label: {
+              text: title,
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            hint: {
+              text: "You do not need to repeat the local planning department’s reasons for issuing the enforcement notice."
+            }
+          }) }}
+
+          <p class="govuk-body">
+            <a href="groundE?enforcement-reason-method=file" class="govuk-link">
+              Upload your reasons in a document
+            </a>
+          </p>
+
+        {% else %}
+
+          <!-- reasons by file -->
+          <label class="govuk-label govuk-label--l" for="enforcement-ground-e-reasons">
+            {{ title  }}
+          </label>
+          <p class="govuk-hint">
+            You do not need to repeat the local planning department’s reasons for issuing the enforcement notice.
+          <p>
+
+          <!-- upload files -->
+          <label class="govuk-label govuk-label--m" for="enforcement-ground-e-reasons">
+            Drag and drop or choose files
+          </label>
+          <input class="govuk-file-upload pins-file-upload" id="enforcement-ground-e-reasons" name="enforcement-ground-e-reasons" type="file" multiple>
+
+        </div>
+
+        {{ govukInsetText({
+          text: "File size should be no more than 15MB"
+        }) }}
+
+        {{ govukDetails({
+          summaryText: "Help with file formats",
+          html: '
+            <p class="govuk-body">
+              Your file must be in one of the following formats:
+            <p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>pdf</li>
+              <li>doc</li>
+              <li>docx</li>
+              <li>tif</li>
+              <li>tiff</li>
+              <li>jpg</li>
+              <li>jpeg</li>
+              <li>png</li>
+            </ul>
+          '
+        }) }}
+
+        <p class="govuk-body">
+          <a href="groundE?enforcement-reason-method=text" class="govuk-link">
+            Explain your reasons using a text box
+          </a>
+        </p>
+
+      {% endif %}
+
+      <!-- route user based on what they selected -->
+      {% if data['grounds-6'] %}
+        {{ govukButton({
+          href: "groundF",
+          text: "Continue"
+        }) }}
+      {% elif data['grounds-7'] %}
+        {{ govukButton({
+          href: "groundG",
+          text: "Continue"
+        }) }}
+      {% else %}
+        {{ govukButton({
+          href: "application",
+          text: "Continue"
+        }) }}
+      {% endif %}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/enforcement/v1/grounds/groundF.html
+++ b/app/views/enforcement/v1/grounds/groundF.html
@@ -1,0 +1,124 @@
+{% extends "layouts/appellant-submission/v11.html" %}
+
+{% set title = "Tell us why you think there’s more work to do than is needed to undo the supposed breach of planning control" %}
+
+{% block pageTitle %}
+  {{title}} - Tell us about the appeal site - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">
+      Choose your grounds of appeal
+    </span>
+
+    <form action="" method="post">
+
+      <div class="govuk-form-group">
+
+        {% if data['enforcement-reason-method'] == 'text' %}
+
+          <!-- reasons by multitext input -->
+          {{ govukTextarea({
+            name: "enforcement-ground-f-reasons",
+            id: "enforcement-ground-f-reasons",
+            label: {
+              text: title,
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            hint: {
+              text: "You do not need to repeat the local planning department’s reasons for issuing the enforcement notice."
+            }
+          }) }}
+
+          <p class="govuk-body">
+            <a href="groundF?enforcement-reason-method=file" class="govuk-link">
+              Upload your reasons in a document
+            </a>
+          </p>
+
+        {% else %}
+
+          <!-- reasons by file -->
+          <label class="govuk-label govuk-label--l" for="enforcement-ground-f-reasons">
+            {{ title  }}
+          </label>
+          <p class="govuk-hint">
+            You do not need to repeat the local planning department’s reasons for issuing the enforcement notice.
+          <p>
+
+          <!-- upload files -->
+          <label class="govuk-label govuk-label--m" for="enforcement-ground-f-reasons">
+            Drag and drop or choose files
+          </label>
+          <input class="govuk-file-upload pins-file-upload" id="enforcement-ground-f-reasons" name="enforcement-ground-f-reasons" type="file" multiple>
+
+        </div>
+
+        {{ govukInsetText({
+          text: "File size should be no more than 15MB"
+        }) }}
+
+        {{ govukDetails({
+          summaryText: "Help with file formats",
+          html: '
+            <p class="govuk-body">
+              Your file must be in one of the following formats:
+            <p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>pdf</li>
+              <li>doc</li>
+              <li>docx</li>
+              <li>tif</li>
+              <li>tiff</li>
+              <li>jpg</li>
+              <li>jpeg</li>
+              <li>png</li>
+            </ul>
+          '
+        }) }}
+
+        <p class="govuk-body">
+          <a href="groundF?enforcement-reason-method=text" class="govuk-link">
+            Explain your reasons using a text box
+          </a>
+        </p>
+
+      {% endif %}
+
+      <!-- route user based on what they selected -->
+      {% if data['grounds-7'] %}
+        {{ govukButton({
+          href: "groundG",
+          text: "Continue"
+        }) }}
+      {% else %}
+        {{ govukButton({
+          href: "application",
+          text: "Continue"
+        }) }}
+      {% endif %}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/enforcement/v1/grounds/groundG.html
+++ b/app/views/enforcement/v1/grounds/groundG.html
@@ -1,0 +1,117 @@
+{% extends "layouts/appellant-submission/v11.html" %}
+
+{% set title = "Tell us why more time is needed to undo the supposed breach of planning control" %}
+
+{% block pageTitle %}
+  {{title}} - Tell us about the appeal site - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">
+      Choose your grounds of appeal
+    </span>
+
+    <form action="" method="post">
+
+      <div class="govuk-form-group">
+
+        {% if data['enforcement-reason-method'] == 'text' %}
+
+          <!-- reasons by multitext input -->
+          {{ govukTextarea({
+            name: "enforcement-ground-g-reasons",
+            id: "enforcement-ground-g-reasons",
+            label: {
+              text: title,
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            hint: {
+              text: "You do not need to repeat the local planning department’s reasons for issuing the enforcement notice."
+            }
+          }) }}
+
+          <p class="govuk-body">
+            <a href="groundG?enforcement-reason-method=file" class="govuk-link">
+              Upload your reasons in a document
+            </a>
+          </p>
+
+        {% else %}
+
+          <!-- reasons by file -->
+          <label class="govuk-label govuk-label--l" for="enforcement-ground-g-reasons">
+            {{ title  }}
+          </label>
+          <p class="govuk-hint">
+            You do not need to repeat the local planning department’s reasons for issuing the enforcement notice.
+          <p>
+
+          <!-- upload files -->
+          <label class="govuk-label govuk-label--m" for="enforcement-ground-g-reasons">
+            Drag and drop or choose files
+          </label>
+          <input class="govuk-file-upload pins-file-upload" id="enforcement-ground-g-reasons" name="enforcement-ground-g-reasons" type="file" multiple>
+
+        </div>
+
+        {{ govukInsetText({
+          text: "File size should be no more than 15MB"
+        }) }}
+
+        {{ govukDetails({
+          summaryText: "Help with file formats",
+          html: '
+            <p class="govuk-body">
+              Your file must be in one of the following formats:
+            <p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>pdf</li>
+              <li>doc</li>
+              <li>docx</li>
+              <li>tif</li>
+              <li>tiff</li>
+              <li>jpg</li>
+              <li>jpeg</li>
+              <li>png</li>
+            </ul>
+          '
+        }) }}
+
+        <p class="govuk-body">
+          <a href="groundG?enforcement-reason-method=text" class="govuk-link">
+            Explain your reasons using a text box
+          </a>
+        </p>
+
+      {% endif %}
+
+      <!-- route user based on what they selected -->
+      {{ govukButton({
+        href: "application",
+        text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Addition of logic so that a person will see file upload for the ground reason questions by default. Then if they change the reason format to text input, they will see text input for the rest of the journey.