### PR TITLE
Enforcement appeal - return of intent date

### DIFF
--- a/app/routes/before-you-start/v12.js
+++ b/app/routes/before-you-start/v12.js
@@ -128,7 +128,7 @@ module.exports = function (router) {
      let intent = req.session.data['enforcement-intent']
 
      // route depending on value
-     if (intent === 'intent') {
+     if (intent === 'Yes') {
        // req.session.data['intent'] = "intent";
        res.redirect(base+'date-of-intent')
      } else {

--- a/app/views/before-you-start/v12/appeal-intent.html
+++ b/app/views/before-you-start/v12/appeal-intent.html
@@ -45,11 +45,11 @@
         },
         items: [
           {
-            value: "intent",
+            value: "Yes",
             text: "Yes, I did submit an intent to appeal"
           },
           {
-            value: "nointent",
+            value: "No",
             text: "No, I did not submit an intent to appeal"
           }
         ]

--- a/app/views/before-you-start/v12/check-answers.html
+++ b/app/views/before-you-start/v12/check-answers.html
@@ -121,7 +121,22 @@
             </dd>
           </div>
 
-          {% if data['intent'] %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Intent to appeal submitted
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ data['enforcement-intent'] }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="notice-decision-date">
+                Change<span class="govuk-visually-hidden"> intent to appeal submitted</span>
+              </a>
+            </dd>
+          </div>
+
+          {% if data['enforcement-intent'] == 'Yes' %}
+
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
                 Intent to appeal submitted date
@@ -141,6 +156,7 @@
                 </a>
               </dd>
             </div>
+
           {% endif %}
 
         </dl>


### PR DESCRIPTION
We just noticed that the intent date is missing from the journey, this brings it back and shows it on the BYS check answers screen.