### PR TITLE
LPA account updates - emails all linked up now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Appeals prototypes
 
-Includes prototypes for the 3 services in PINS appeals, `Appeal a planning decision` for appellants and agents, `Manage appeals` for LPAs, and `Find and comment on an appeal` for interested parties.
+Includes prototypes for the 3 services in PINS appeals, `Appeal a planning decision` for appellants and agents, `Manage your planning inspectorate appeals` for LPAs, and `Find and comment on an appeal` for interested parties.
 
 ## Usage
 

--- a/app/views/_layouts/layout-email.html
+++ b/app/views/_layouts/layout-email.html
@@ -1,0 +1,58 @@
+{% block head %}
+  <!--[if lte IE 8]><link href="/public/stylesheets/unbranded-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/public/stylesheets/unbranded.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+{% endblock %}
+
+{% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
+
+{% block header %}{% endblock %}
+{% extends '_layouts/layout-includes.html' %}
+
+
+{# Add the title(h1) to page title if it's set, add to each page with:
+{% set title = 'Example' %} #}
+{% block pageTitle %}
+	{{ title+' –' if title }} {{ serviceName }}
+{% endblock %}
+
+{# Add the phase banner and back link to each page #}
+{% block beforeContent %}
+{% endblock %}
+
+{# Setup form question pages by default, override by using content block if not needed #}
+{% block content %}
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-two-thirds">
+
+			{# Forms all post to themselves, action controlled by _routes.js in each prototype #}
+			<form method="post">
+
+				{# Use the questions block on each page without needing to add in the rest of this block #}
+				{% block questions %}{% endblock %}
+
+				{# Set default button to continue, use buttons block to override #}
+				{% block buttons %}
+					{{ govukButton({
+						text: 'Continue'
+					}) }}
+
+					{# Option to add a return to task list link
+					Add on pages that with:
+						{% set return = true %}
+
+					or add for whole prototype in routes.js with:
+						res.locals['return'] = true
+					#}
+					{% if return == true %}
+						<p><a href="../task-list" class="govuk-link--no-visited-state">Return to task list</a></p>
+					{% endif %}
+				{% endblock %}
+
+			</form>
+
+		</div>
+	</div>
+{% endblock %}
+
+{% block footer %}
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -60,11 +60,26 @@
       </h2>
 
       <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+        Emails
+      </h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <a href="/manage/emails/v1/service-invite">Service invite</a>
+        </li>
+        <li>
+          <a href="/manage/emails/v1/appeal-valid">Appeal started</a>
+        </li>
+        <li>
+          <a href="/manage/emails/v1/appeal-statements">Appeal statements (cross-copy)</a>
+        </li>
+      </ul>
+
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
         Common journeys and patterns
       </h3>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="manage/appeals/">Local authority appeals</a>
+          <a href="manage/appeals/?questionnaire=&statement=&finalcomments=">Local authority appeals</a>
         </li>
         <li>
           <a href="manage/manage-users/">Manage users</a>

--- a/app/views/manage/access/v1/_routes.js
+++ b/app/views/manage/access/v1/_routes.js
@@ -1,0 +1,30 @@
+const express = require('express')
+const router = new express.Router()
+
+router.get('*', function(req, res, next){
+  // Change the service name for this feature
+  res.locals['serviceName'] = 'Manage your planning inspectorate appeals'
+
+  next()
+})
+
+
+router.post('/enter-code', function (req, res) {
+
+  // find out where the journey started
+  let start = req.session.data['start']
+
+  // route depending on value
+  if (start === 'invite') {
+    res.redirect('/manage/appeals/v2/?no-appeals=true')
+  } else if (start === 'questionnaire') {
+    res.redirect('/manage/questionnaire/v11/task-list')
+  } else {
+    res.redirect('/manage/final-comments/v1/add-comments')
+  }
+
+})
+
+
+// Add your routes above the module.exports line
+module.exports = router

--- a/app/views/manage/access/v1/check-email.html
+++ b/app/views/manage/access/v1/check-email.html
@@ -1,0 +1,57 @@
+{% extends '_layouts/layout-pins.html' %}
+
+{% set serviceName = "Manage your planning inspectorate appeals" %}
+
+{% set title = "Confirm you want to add this user" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {# {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }} #}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form method="post">
+
+      <label class="govuk-label govuk-label--l" for="email">
+        {{ title }}
+      </label>
+
+      <p class="govuk-body-l">
+        Add {% if data['email'] %}
+          {{ data['email']+"@leeds.gov.uk" }}
+        {% else %}
+          example@leeds.gov.uk
+        {% endif %}
+      </p>
+
+      {# {{ govukInsetText({
+        html: data['email']
+      }) }} #}
+
+      {{ govukButton({
+        text: "Add user"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/manage/access/v1/email.html
+++ b/app/views/manage/access/v1/email.html
@@ -1,0 +1,59 @@
+{% set pageref = "" %}
+{% extends location+"_layout.html" %}
+
+{% set serviceName = "Manage your planning inspectorate appeals" %}
+
+{% set title = "Enter your email address" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+      <form method="post">
+
+        <span class="govuk-caption-l">{{ subServiceName }}</span>
+
+        <div class="govuk-form-group">
+
+          <label class="govuk-label govuk-label--l" for="email">
+            {{ title }}
+          </label>
+
+          <div class="govuk-form-group">
+            <input class="govuk-input" id="myemail" name="myemail" type="email" spellcheck="false" autocomplete=none value="">
+          </div>
+
+        </div>
+
+        {% include "includes/button.html" %}
+
+      </form>
+
+      <!-- this is a prototype only link -->
+      {# <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9 govuk-!-margin-top-9">
+        <p class="govuk-body-s pins-prototype-only">
+          <a href="lpa-questionnaire/v10">
+            To the questionnaire
+          </a>
+        </p>
+      </div> #}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/manage/access/v1/enter-code.html
+++ b/app/views/manage/access/v1/enter-code.html
@@ -1,0 +1,46 @@
+{% extends '_layouts/layout-pins.html' %}
+
+{% set serviceName = "Manage your planning inspectorate appeals" %}
+{% set nav = true %}
+
+{% set title = "Enter the code we sent to your email address" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+{% endblock %}
+
+{% block questions %}
+
+  <span class="govuk-caption-l">{{ subServiceName }}</span>
+
+  <div class="govuk-form-group">
+
+    <label class="govuk-label govuk-label--l" for="email">
+      {{ title }}
+    </label>
+
+    <div class="govuk-form-group">
+      <input class="govuk-input govuk-input--width-5" id="email" name="email" type="text" spellcheck="false" autocomplete=none value="" style="text-transform:uppercase">
+    </div>
+
+  </div>
+
+  <div class="govuk-!-margin-bottom-6">
+    <p class="govuk-body">
+      <a href="request-code" class="govuk-!-margin-bottom-9">
+        Not received the code?
+      </a>
+    </p>
+  </div>
+
+{% endblock %}

--- a/app/views/manage/access/v1/request-code.html
+++ b/app/views/manage/access/v1/request-code.html
@@ -1,0 +1,51 @@
+{% extends '_layouts/layout-pins.html' %}
+
+{% set serviceName = "Manage your planning inspectorate appeals" %}
+
+{% set title = "Request a new code" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <span class="govuk-caption-l">{{ subServiceName }}</span>
+
+    <div class="govuk-form-group">
+
+      <label class="govuk-label govuk-label--l" for="postcode">
+        {{ title }}
+      </label>
+
+      <p class="govuk-body">
+        Emails sometimes take a few minutes to arrive. If you do not receive the code, you can request a new one.
+      </p>
+
+      {{ govukButton({
+        href: "enter-code",
+        text: "Request a new code"
+      }) }}
+
+    </div>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/manage/access/v1/start.html
+++ b/app/views/manage/access/v1/start.html
@@ -1,0 +1,76 @@
+{% set pageref = "" %}
+{% extends location+"_layout.html" %}
+
+{% set serviceName = "Manage your planning inspectorate appeals" %}
+
+{% set title = "View and manage planning appeals" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {# {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }} #}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">{{ subServiceName }}</span>
+
+    <h1 class="govuk-heading-l">
+      {{ title }}
+    </h1>
+
+    <section class="govuk-!-margin-bottom-6">
+
+      <p class="govuk-body">
+        This is a new service for local planning authorities (LPAs). You can use the service to:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          view new and in progress planning appeals
+        </li>
+        <li>
+          view, edit and submit an appeal questionnaire
+        </li>
+        {# <li>
+          invite someone else to view and edit an appeal questionnaire
+        </li> #}
+        <li>
+          add and remove users
+        </li>
+      </ul>
+
+    </section>
+
+    <h2 class="govuk-heading-m">
+      Who can use this service
+    </h2>
+
+    <p class="govuk-body">
+      You must have a local authority email address to use this service.
+    </p>
+
+    {{ govukButton({
+      href: "email",
+      text: "Start now"
+    }) }}
+
+  </div>
+
+</div>
+{% endblock %}

--- a/app/views/manage/appeals/v2/_routes.js
+++ b/app/views/manage/appeals/v2/_routes.js
@@ -3,18 +3,10 @@ const router = new express.Router()
 
 router.get('*', function(req, res, next){
   // Change the service name for this feature
-  res.locals['serviceName'] = 'Manage appeals'
+  res.locals['serviceName'] = 'Manage your planning inspectorate appeals'
 
   next()
 })
-
-
-
-
-
-
-
-
 
 // Add your routes above the module.exports line
 module.exports = router

--- a/app/views/manage/appeals/v2/index.html
+++ b/app/views/manage/appeals/v2/index.html
@@ -1,7 +1,24 @@
 {% extends '_layouts/layout-pins.html' %}
-{% set prototypeLinks = [{href: './?no-appeals=true', text: 'No appeals'}] if data['no-appeals'] != 'true' else [{href: './?no-appeals=false&questionnaire=&finalcomments=', text: 'Show appeals'}] %}
+<!-- {% set prototypeLinks = [{href: './?no-appeals=true', text: 'No appeals'}] if data['no-appeals'] != 'true' else [{href: './?no-appeals=false&questionnaire=&finalcomments=&statement=', text: 'Show appeals'}]%} -->
+{% set prototypeLinks = [
+  {
+    href: './?no-appeals=true',
+    text: 'No appeals'
+  },
+  {
+    href: './?no-appeals=false&questionnaire=&statement=&finalcomments=',
+    text: 'Reset appeals'
+  }
 
-{% set serviceName = "Manage appeals" %}
+  ] if data['no-appeals'] != 'true' else [{
+    href: './?no-appeals=false&questionnaire=&finalcomments=&statement=',
+    text: 'Show appeals'
+  }]
+%}
+
+
+
+{% set serviceName = "Manage your planning inspectorate appeals" %}
 {% set nav = true %}
 
 {% set title = 'Planning appeals' %}
@@ -26,9 +43,11 @@
       {{ title }}
     </h1>
 
-    <p>{{ 'Planning appeals will be shown here. ' if data['no-appeals'] == 'true' }}All users will be notified by email when a new appeal is added.</p>
-
-    <p><a href="../../manage-users/v2/" class="govuk-link--no-visited-state">Add and remove account users</a></p>
+    <p>
+      <a href="/manage/manage-users/v2/" class="govuk-link--no-visited-state">
+        Add and remove account users
+      </a>
+    </p>
   </div>
 
   {% if data['no-appeals'] != 'true' %}
@@ -49,10 +68,11 @@
             html: 'Deadline'
           },
           {
-            html: 'Due in'
+            html: 'Due in',
+            format: 'numeric'
           },
           {
-            html: '<span class="govuk-visually-hidden">Actions</span>',
+            html: 'To do',
             format: 'numeric'
           }
         ],
@@ -68,10 +88,11 @@
               html: '3' | daysInFuture
             },
             {
-              html: '3 days'
+              html: '3 days',
+              format: 'numeric'
             },
             {
-              html: '<a href="/manage/questionnaire/v11/task-list">Complete questionnaire</a>',
+              html: '<span class="govuk-visually-hidden">Submit </span><a href="/manage/questionnaire/v11/task-list">Questionnaire</a>',
               format: 'numeric'
             }
           ] if data['questionnaire'] != 'complete',
@@ -86,10 +107,11 @@
               html: '4' | daysInFuture
             },
             {
-              html: '4 days'
+              html: '4 days',
+              format: 'numeric'
             },
             {
-              html: '<a href="/manage/final-comments/v1/add-comments">Add final comments</a>',
+              html: '<span class="govuk-visually-hidden">Submit </span><a href="/manage/final-comments/v1/add-comments">Final comments</a>',
               format: 'numeric'
             }
           ] if data['finalcomments'] != 'complete',
@@ -101,67 +123,71 @@
               html: '21/02939/FUL'
             },
             {
-              html: '7' | daysInFuture
+              html: '6' | daysInFuture
             },
             {
-              html: '7 days'
+              html: '6 days',
+              format: 'numeric'
             },
             {
-              html: '<a href="/manage/questionnaire/v11/task-list">Complete questionnaire</a>',
+              html: '<span class="govuk-visually-hidden">Submit </span><a href="/manage/questionnaire/v11/task-list">Questionnaire</a>',
               format: 'numeric'
             }
           ],
           [
             {
-              html: 'APP/Q9999/D/21/1345264'
+              html: 'APP/Q9999/D/21/1345172'
+            },
+            {
+              html: '21/04125/FUL'
+            },
+            {
+              html: '7' | daysInFuture
+            },
+            {
+              html: '7 days',
+              format: 'numeric'
+            },
+            {
+              html: '<span class="govuk-visually-hidden">Submit </span><a href="/manage/questionnaire/v11/task-list">Questionnaire</a>',
+              format: 'numeric'
+            }
+          ],
+          [
+            {
+              html: 'APP/Q9999/D/21/1345222'
             },
             {
               html: '21/05057/FUL'
             },
             {
-              html: '25' | daysInFuture
-            },
-            {
-              html: '25 days'
-            },
-            {
-              html: '<a href="/manage/questionnaire/v11/task-list">Complete questionnaire</a>',
-              format: 'numeric'
-            }
-          ],
-          [
-            {
-              html: 'APP/Q9999/D/21/1345264'
-            },
-            {
-              html: '21/04625/FUL'
-            },
-            {
               html: '27' | daysInFuture
             },
             {
-              html: '27 days'
+              html: '27 days',
+              format: 'numeric'
             },
             {
-              html: '<a href="/manage/statement/v1/enter-statement">Add appeal statement</a>',
+              html: '<span class="govuk-visually-hidden">Submit </span><a href="/manage/statement/v1/enter-statement">Statement</a>',
               format: 'numeric'
             }
-          ],
+          ]  if data['statement'] != 'complete',
           [
             {
-              html: 'APP/Q9999/D/22/1345264'
+              html: 'APP/Q9999/D/22/1345331'
             },
             {
-              html: '22/05058/FUL'
+              html: '22/04782/FUL'
             },
             {
               html: '31' | daysInFuture
             },
             {
-              html: '31 days'
+              html: '31 days',
+              format: 'numeric'
             },
             {
-              html: '<a href="/manage/statement/v1/enter-statement">Add appeal statement</a>',
+              html: '<span class="govuk-visually-hidden">Submit </span><a href="/manage/statement/v1/enter-statement">Statement</a>',
               format: 'numeric'
             }
           ] if data['questionnaire'] == 'complete'

--- a/app/views/manage/emails/index.html
+++ b/app/views/manage/emails/index.html
@@ -1,7 +1,7 @@
 {% extends '_layouts/layout-pins.html' %}
 
 {% set nav = true %}
-{% set title = 'Planning appeals' %}
+{% set title = 'Emails to the LPA' %}
 
 {% block backLink %}
   {{ govukBackLink({
@@ -21,7 +21,7 @@
       {{ title }}
     </h1>
 
-    {% set version = "2" %}
+    {% set version = "1" %}
     <h2 class="govuk-heading-m">
       Version {{version}}
       {{ govukTag({
@@ -30,21 +30,21 @@
       }) }}
     </h2>
 
-    <p class="govuk-!-margin-bottom-2">Changes:</p>
+    <p class="govuk-!-margin-bottom-2">
+
+    </p>
+
     <ul class="govuk-list govuk-list--bullet">
-      <li>moved the work to the new prototype (<a href="https://pins-appeals.herokuapp.com/lpa/v1/no-appeals" class="govuk-link govuk-link--no-visited-state" title="Link to version 1">see version 1</a>)</li>
-      <li>changed to one link per task</li>
-      <li>appeal statement link not shown till questionnaire is done</li>
-      <li>completed questionnaire drops to the foot of the list with statement action</li>
-      <li>completed final comments appeal in the 2nd row disappears</li>
-      <li>completed statetment appeal in the 5th row disappears</li>
+      <li><a href="v1/service-invite" class="govuk-link">Invite to the service</a></li>
+      <li><a href="v1/appeal-valid" class="govuk-link">Appeal valid, do the questionnaire</a></li>
+      <li><a href="v1/appeal-statements" class="govuk-link">Appeal statements (cross-copy)</a></li>
     </ul>
 
-    {{ govukButton({
+    <!-- {{ govukButton({
       html: 'View prototype',
       href: 'v'+version+'/',
       isStartButton: true
-    }) }}
+    }) }} -->
 
     {% set lpaForm %}
       <form method="get" action="v{{version}}/">

--- a/app/views/manage/emails/v1/appeal-statements.html
+++ b/app/views/manage/emails/v1/appeal-statements.html
@@ -1,0 +1,90 @@
+{% extends '_layouts/layout-email.html' %}
+
+{% block pageTitle %}
+  Submit appeal statements for 21/04125/FUL
+{% endblock %}
+
+{% block content %}
+<!-- faux email header -->
+<section>
+    <p>
+    <strong>Subject:</strong> 21/04125/FUL - Submit appeal statements
+  </p>
+  <p>
+    <strong>To:</strong> planning.appeals{{ data['lpa-email']}}<br>
+    <strong>From:</strong> info@planninginspectorate.gov.uk
+  </p>
+  <!-- <p>
+    <img src="{{ asset_path }}images/pi-logo.png" width="150" alt="Planning Inspectorate logo, Royal coat of arms of the United Kingdom in black and white. A lion wearing a crown and a unicorn dance either side of a crest with a crown on it."/>
+  </p> -->
+  <hr>
+</section>
+
+<div class="govuk-grid-row govuk-!-margin-top-5">
+  <div class="govuk-grid-column-two-thirds">
+
+    <p class="govuk-body">
+      Appeal site: 11 Gifford Way, Sampleford, BS15 2AP
+    </p>
+
+    <p class="govuk-body">
+      Appeal reference: 21/04125/FUL
+    </p>
+
+    <br>
+
+    <p class="govuk-body">
+      Dear {{ data['dashboard-lpa'] }},
+    </p>
+
+    <p class="govuk-body">
+      The appellant has submitted their appeal statements for planning application 1345172.
+    </p>
+
+    <p class="govuk-body">
+      We've attached the statement for your information.
+    </p>
+
+    <p class="govuk-body">
+      This is due by {{ 7 | daysInFuture }}
+    </p>
+
+    <h2 class="govuk-heading-m">
+      What you can do
+    </h2>
+
+    <p class="govuk-body">
+      You can complete your questionnaire online in our new ‘Manage your planning inspectorate appeals’ service.
+    </p>
+
+    <p class="govuk-body">
+      To complete your questionnaire, you need to click the link to receive a secure code. We’ll send you a code to sign into your account with. You can then view, edit, share and submit the questionnaire online.
+    </p>
+
+
+    <!-- there were problems with this in research when we tested it for save and return -->
+    <!-- which is why we added a numbered list -->
+    <!-- it worked a lot better -->
+
+    <!-- <p class="govuk-body">
+      Go to the link to receive a code:<br>
+      <a href="enter-code?start=questionnaire" class="govuk-link">https://manage-appeals.planninginspectorate.gov.uk/appeal/04125/final-comments?/lpa=1vW7td12</a>
+    </p> -->
+
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        Go to the link to receive a code:<br>
+        <a href="/manage/access/v1/enter-code?start=statements" class="govuk-link">https://manage-appeals.planninginspectorate.gov.uk/appeal/04125/final-comments?/lpa=1vW7td12</a>
+      </li>
+      <li>
+        Enter the code we send in an email to you.
+      </li>
+    </ol>
+
+    <p class="govuk-body">
+      The Planning Inspectorate
+    </p>
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/manage/emails/v1/appeal-valid.html
+++ b/app/views/manage/emails/v1/appeal-valid.html
@@ -1,0 +1,85 @@
+{% extends '_layouts/layout-email.html' %}
+
+{% block pageTitle %}
+  Submit questionnaire for 21/02939/FUL
+{% endblock %}
+
+{% block content %}
+<!-- faux email header -->
+<section>
+    <p>
+    <strong>Subject:</strong> 21/02939/FUL - Submit questionnaire
+  </p>
+  <p>
+    <strong>To:</strong> planning.appeals{{ data['lpa-email']}}<br>
+    <strong>From:</strong> info@planninginspectorate.gov.uk
+  </p>
+  <!-- <p>
+    <img src="{{ asset_path }}images/pi-logo.png" width="150" alt="Planning Inspectorate logo, Royal coat of arms of the United Kingdom in black and white. A lion wearing a crown and a unicorn dance either side of a crest with a crown on it."/>
+  </p> -->
+  <hr>
+</section>
+
+<div class="govuk-grid-row govuk-!-margin-top-5">
+  <div class="govuk-grid-column-two-thirds">
+
+    <p class="govuk-body">
+      Appeal site: 11 Bradling Avenue, Sampleford, BS17 2PP
+    </p>
+
+    <p class="govuk-body">
+      Appeal reference: 21/02939/FUL
+    </p>
+
+    <br>
+
+    <p class="govuk-body">
+      Dear {{ data['dashboard-lpa'] }},
+    </p>
+
+    <p class="govuk-body">
+      The appeal for application 1345260 has been validated and you can now submit your questionnaire.
+    </p>
+
+    <p class="govuk-body">
+      This is due by {{ 7 | daysInFuture }}
+    </p>
+
+    <h2 class="govuk-heading-m">
+      What you can do
+    </h2>
+
+    <p class="govuk-body">
+      You can complete your questionnaire online in our new ‘Manage your appeals’ service.
+    </p>
+
+    <p class="govuk-body">
+      To complete your questionnaire, you need to click the link to receive a secure code. We’ll send you a code to sign in to your account. You can then view, edit and submit the questionnaire online.
+    </p>
+
+    <!-- there were problems with this in research when we tested it for save and return -->
+    <!-- which is why we added a numbered list -->
+    <!-- it worked a lot better -->
+
+    <!-- <p class="govuk-body">
+      Go to the link to receive a code:<br>
+      <a href="enter-code?start=questionnaire" class="govuk-link">https://manage-appeals.planninginspectorate.gov.uk/appeal/04125?/lpa=d81vW7td12s4t5gff728y29</a>
+    </p> -->
+
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        Go to the link to receive a code:<br>
+        <a href="/manage/access/v1/enter-code?start=questionnaire" class="govuk-link">https://manage-appeals.planninginspectorate.gov.uk/appeal/04125?/lpa=1vW7td12</a>
+      </li>
+      <li>
+        Enter the code we send in an email to you.
+      </li>
+    </ol>
+
+    <p class="govuk-body">
+      The Planning Inspectorate
+    </p>
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/manage/emails/v1/service-invite.html
+++ b/app/views/manage/emails/v1/service-invite.html
@@ -1,0 +1,91 @@
+{% extends '_layouts/layout-email.html' %}
+
+{% block pageTitle %}
+  Invitation to your new account
+{% endblock %}
+
+{% block content %}
+<!-- faux email header -->
+<section>
+    <p>
+    <strong>Subject:</strong> Invitation to your new account
+  </p>
+  <p>
+    <strong>To:</strong> planning.appeals{{ data['lpa-email']}}<br>
+    <strong>From:</strong> info@planninginspectorate.gov.uk
+  </p>
+  <hr>
+</section>
+
+<div class="govuk-grid-row govuk-!-margin-top-5">
+  <div class="govuk-grid-column-two-thirds">
+
+    <p class="govuk-body">
+      Dear {{ data['dashboard-lpa'] }}
+    </p>
+
+    <p class="govuk-body">
+      The Planning Inspectorate has launched a new service for local planning authorities (LPAs) to manage appeals and has created a new account for {{ data['dashboard-lpa'] }}.
+    </p>
+
+    <p class="govuk-body">
+      You can use the ‘Manage your planning inspectorate appeals’ service to:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        view and manage an appeal’s progress
+      </li>
+      <li>
+        complete and submit an appeal questionnaire
+      </li>
+      <li>
+        complete and submit the:
+      </li>
+        <ol class="govuk-list govuk-list--bullet">
+          <li>
+            appeal questionnaire
+          </li>
+          <li>
+            appeal statements
+          </li>
+          <li>
+            final comments
+          </li>
+        </ol>
+      {# <li>
+        invite someone else to view and edit an appeal questionnaire
+      </li> #}
+
+    </ul>
+
+    <h2 class="govuk-heading-m">
+      What you can do
+    </h2>
+
+    <!-- there were problems with this in research when we tested it for save and return -->
+    <!-- which is why we added a numbered list -->
+    <!-- it worked a lot better -->
+
+    <!-- <p class="govuk-body">
+      To view your new account and add your team, follow the link to receive a secure code:<br>
+      <a href="/manage/access/enter-code?start=invite" class="govuk-link">https://manage-appeals.planninginspectorate.gov.uk/service-invite?lpa=d81vW7td12s4t5gff728y29</a>
+    </p> -->
+
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        Go to the link to receive a code:<br>
+        <a href="/manage/access/v1/enter-code?start=invite" class="govuk-link">https://manage-appeals.planninginspectorate.gov.uk/service-invite?lpa=1vW7td12</a>
+      </li>
+      <li>
+        Enter the code we send in an email to you.
+      </li>
+    </ol>
+
+    <p class="govuk-body">
+      The Planning Inspectorate
+    </p>
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/manage/final-comments/v1/_routes.js
+++ b/app/views/manage/final-comments/v1/_routes.js
@@ -3,7 +3,7 @@ const router = new express.Router()
 
 router.get('*', function(req, res, next){
   // Change the service name for this feature
-  res.locals['serviceName'] = 'Manage appeals'
+  res.locals['serviceName'] = 'Manage your planning inspectorate appeals'
   next()
 })
 

--- a/app/views/manage/final-comments/v1/add-comments.html
+++ b/app/views/manage/final-comments/v1/add-comments.html
@@ -28,7 +28,7 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
 
       {# Tweak the summary list to be smaller #}
 
@@ -74,6 +74,12 @@
           }
         ]
       }) }}
+
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 

--- a/app/views/manage/final-comments/v1/confirmation.html
+++ b/app/views/manage/final-comments/v1/confirmation.html
@@ -27,10 +27,10 @@
         What happens next
       </h2>
 
-      <p>We&rsquo;ll check you've submitted everything we need to progress the appeal and will contact you if anything is missing.</p>
+      <p>We’ll check you’ve submitted everything we need to progress the appeal and will contact you if anything is missing.</p>
 
       <p>
-        <a href="../../appeals/v2/?finalcomments=complete" class="govuk-link--no-visited-state">View your planning appeals</a>
+        <a href="/manage/appeals/v2/?no-appeals=false&finalcomments=complete" class="govuk-link--no-visited-state">View your planning appeals</a>
       </p>
 
     </div>

--- a/app/views/manage/manage-users/v2/_routes.js
+++ b/app/views/manage/manage-users/v2/_routes.js
@@ -3,7 +3,7 @@ const router = new express.Router()
 
 router.get('*', function(req, res, next){
   // Change the service name for this feature
-  res.locals['serviceName'] = 'Manage appeals'
+  res.locals['serviceName'] = 'Manage your planning inspectorate appeals'
 
   next()
 })

--- a/app/views/manage/manage-users/v2/add-user--confirm.html
+++ b/app/views/manage/manage-users/v2/add-user--confirm.html
@@ -2,6 +2,19 @@
 
 {% set title = 'Confirm you want to add this user' %}
 
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    html: 'Back',
+    href: 'javascript:history.back()'
+  }) }}
+{% endblock %}
+
 {% block questions %}
   <h1 class="govuk-heading-l">
     {{ title }}

--- a/app/views/manage/manage-users/v2/add-user.html
+++ b/app/views/manage/manage-users/v2/add-user.html
@@ -2,6 +2,19 @@
 
 {% set title = 'What is their email address?' %}
 
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    html: 'Back',
+    href: 'javascript:history.back()'
+  }) }}
+{% endblock %}
+
 {% block questions %}
   {{ govukInput({
     id: 'add-user-email',

--- a/app/views/manage/manage-users/v2/index.html
+++ b/app/views/manage/manage-users/v2/index.html
@@ -2,7 +2,13 @@
 
 {% set title = 'Manage account users' %}
 
-{% block backLink %}
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
   {{ govukBackLink({
     html: 'Back to planning appeals',
     href: '../../appeals/v2/'
@@ -39,14 +45,17 @@
 
       <h1 class="govuk-heading-l">
         {{ title }}
-        test: {{notification}}
       </h1>
 
-      <p>All users can add information to appeals and will receive email notifications about new appeals.</p>
+      <p>
+        All users can add information to appeals. When a new appeal is added and a task is submitted, an email notification will be sent to all account users.
+      </p>
 
-      <p><a href="add-user" class="govuk-link--no-visited-state">Add a user</a></p>
-
-
+      <p>
+        <a href="add-user" class="govuk-link--no-visited-state">
+          Add a user
+        </a>
+      </p>
 
       <h2 class="govuk-heading-m app-border-top-big govuk-!-padding-top-6 govuk-!-margin-top-6">
         Current users

--- a/app/views/manage/manage-users/v2/remove-user.html
+++ b/app/views/manage/manage-users/v2/remove-user.html
@@ -2,6 +2,19 @@
 
 {% set title = 'Confirm you want to remove this user' %}
 
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+  {{ govukBackLink({
+    html: 'Back',
+    href: 'javascript:history.back()'
+  }) }}
+{% endblock %}
+
 {% block questions %}
   <h1 class="govuk-heading-l">
     {{ title }}

--- a/app/views/manage/questionnaire/v10/_routes.js
+++ b/app/views/manage/questionnaire/v10/_routes.js
@@ -3,7 +3,7 @@ const router = new express.Router()
 
 router.get('*', function(req, res, next){
   // Change the service name for this feature
-  res.locals['serviceName'] = 'Manage appeals'
+  res.locals['serviceName'] = 'Manage your planning inspectorate appeals'
 
   // Add return to task list
   res.locals['return'] = true

--- a/app/views/manage/questionnaire/v11/_routes.js
+++ b/app/views/manage/questionnaire/v11/_routes.js
@@ -4,7 +4,7 @@ const router = new express.Router()
 router.get('*', function(req, res, next){
 
   // Change the service name for this feature
-  res.locals['serviceName'] = 'Manage appeals'
+  res.locals['serviceName'] = 'Manage your planning inspectorate appeals'
 
   // Add return to task list
   res.locals['return'] = true

--- a/app/views/manage/questionnaire/v11/confirmation.html
+++ b/app/views/manage/questionnaire/v11/confirmation.html
@@ -33,7 +33,7 @@
       <p>We&rsquo;ll review your evidence and will be in touch if we need any further information.</p>
 
       <p>
-        <a href="../../appeals/v2/?questionnaire=complete" class="govuk-link--no-visited-state">View your planning appeals</a>
+        <a href="../../appeals/v2/??no-appeals=false&questionnaire=complete" class="govuk-link--no-visited-state">View your planning appeals</a>
       </p>
 
     </div>

--- a/app/views/manage/statement/v1/_layout-old.html
+++ b/app/views/manage/statement/v1/_layout-old.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% set bodyClasses = bodyClasses | default("internal") %}
-{% set serviceName = '<span class="dept">Planning Inspectorate</span> Manage Appeals' | safe %}
+{% set serviceName = '<span class="dept">Planning Inspectorate</span> Manage your planning inspectorate appeals' | safe %}
 {% block pageTitle %}
-  Manage Appeals — Planning Inspectorate
+  Manage your planning inspectorate appeals — Planning Inspectorate
 {% endblock %}

--- a/app/views/manage/statement/v1/_layout.html
+++ b/app/views/manage/statement/v1/_layout.html
@@ -1,9 +1,9 @@
 {% extends "layout.html" %}
 
 {% set bodyClasses = bodyClasses | default("internal") %}
-{% set serviceName = '<span class="dept">Planning Inspectorate</span> Manage Appeals' | safe %}
+{% set serviceName = '<span class="dept">Planning Inspectorate</span> Manage your planning inspectorate appeals' | safe %}
 {% block pageTitle %}
-  Manage Appeals — Planning Inspectorate
+  Manage your planning inspectorate appeals — Planning Inspectorate
 {% endblock %}
 
 {% block content %}

--- a/app/views/manage/statement/v1/_routes.js
+++ b/app/views/manage/statement/v1/_routes.js
@@ -2,7 +2,7 @@ const express = require('express')
 const router = new express.Router()
 router.get('*', function(req, res, next){
   // Change the service name for this feature
-  res.locals['serviceName'] = 'Manage appeals'
+  res.locals['serviceName'] = 'Manage your planning inspectorate appeals'
   next()
 })
 // enter code

--- a/app/views/manage/statement/v1/check-your-answers.html
+++ b/app/views/manage/statement/v1/check-your-answers.html
@@ -2,7 +2,7 @@
 
 {% set title = "Do you have additional documents to support your appeal statement?" %}
 
-{% set serviceName = "Manage appeals" %}
+{% set serviceName = "Manage your planning inspectorate appeals" %}
 {% set nav = true %}
 
 {% block beforeContent %}

--- a/app/views/manage/statement/v1/confirmation.html
+++ b/app/views/manage/statement/v1/confirmation.html
@@ -2,7 +2,7 @@
 
 {% set title = "Appeal statement submitted" %}
 
-{% set serviceName = "Manage appeals" %}
+{% set serviceName = "Manage your planning inspectorate appeals" %}
 {% set nav = true %}
 
 {% block beforeContent %}
@@ -35,11 +35,7 @@
       </p>
 
       <p class="govuk-!-margin-bottom-5">
-        <a href="/manage/appeals/v2/">Back to appeals</a>
-      </p>
-
-      <p>
-        <a href="#0">What did you think of this service?</a> (takes 30 seconds)
+        <a href="/manage/appeals/v2/?statement=complete">Back to appeals</a>
       </p>
 
     </div>

--- a/app/views/manage/statement/v1/documents-check.html
+++ b/app/views/manage/statement/v1/documents-check.html
@@ -2,7 +2,7 @@
 
 {% set title = "Do you have additional documents to support your appeal statement?" %}
 
-{% set serviceName = "Manage appeals" %}
+{% set serviceName = "Manage your planning inspectorate appeals" %}
 {% set nav = true %}
 
 {% block beforeContent %}

--- a/app/views/manage/statement/v1/documents-upload.html
+++ b/app/views/manage/statement/v1/documents-upload.html
@@ -2,7 +2,7 @@
 
 {% set title = "Do you have additional documents to support your appeal statement?" %}
 
-{% set serviceName = "Manage appeals" %}
+{% set serviceName = "Manage your planning inspectorate appeals" %}
 {% set nav = true %}
 
 {% block beforeContent %}

--- a/app/views/manage/statement/v1/enter-statement.html
+++ b/app/views/manage/statement/v1/enter-statement.html
@@ -1,9 +1,9 @@
 {% extends '_layouts/layout-pins.html' %}
 
-{% set serviceName = "Manage appeals" %}
+{% set serviceName = "Manage your planning inspectorate appeals" %}
 {% set nav = true %}
 
-{% set title = "Enter your statement" %}
+{% set title = "Your appeal statement" %}
 
 {% block beforeContent %}
   {{ govukPhaseBanner({
@@ -87,7 +87,7 @@
         name: "appeal-statement",
         id: "appeal-statement",
         label: {
-          html: 'Your appeal statement',
+          html: 'Enter your statement',
           classes: 'govuk-label--m'
         }
       }) }}


### PR DESCRIPTION
Updates to lpa account and appeal processes
- added the email start points (statement needs review)
- added save and return code step
- when the statement (5th row) is complete it disappears
- reverted email link presentation to ordered list, in previous research users found it hard to understand as a sentence