### PR TITLE
Interested parties can find and comment on appeals

### DIFF
--- a/app/views/_includes/sensitive-information-list.html
+++ b/app/views/_includes/sensitive-information-list.html
@@ -1,0 +1,28 @@
+{% set sensitiveHTML %}
+	<p class="govuk-!-margin-bottom-2">Sensitive information refers to:</p>
+	<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+		<li>comments from children</li>
+		<li>information relating to children</li>
+		<li>information relating to health</li>
+		<li>information relating to crime</li>
+		<li>
+			any information relating to an individual&rsquo;s:
+			<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+				<li>race</li>
+				<li>ethnic origin</li>
+				<li>politics</li>
+				<li>religion</li>
+				<li>trade union membership</li>
+				<li>genetics</li>
+				<li>physical characteristics</li>
+				<li>sex life</li>
+				<li>sexual orientation</li>
+			</ul>
+		</li>
+	</ul>
+{% endset -%}
+
+{{ govukDetails({
+	summaryHtml: 'What is sensitive information?',
+	html: sensitiveHTML
+}) }}

--- a/app/views/appeal/find-appeal/index.html
+++ b/app/views/appeal/find-appeal/index.html
@@ -32,12 +32,17 @@
     </h2>
 
     <p class="govuk-body">
+      This is the previous design work for interested parties, finding and commenting on an appeal.
+    </p>
+
+    <p class="govuk-body">
       Changes:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>moved the work to the new prototype (<a href="https://pins-appeals.herokuapp.com/interested-party/v4/guidance" class="govuk-link govuk-link--no-visited-state">see version 4</a>)</li>
-      <li>Updates to follow…</li>
+      <li>updated the colour of the appeal tags to align them with GDS style</li>
+      <li>iteration to follow to update some of the patterns here</li>
     </ul>
 
     {{ govukButton({

--- a/app/views/appeal/find-appeal/index.html
+++ b/app/views/appeal/find-appeal/index.html
@@ -1,0 +1,98 @@
+{% extends '_layouts/layout-pins.html' %}
+
+{% set nav = false %}
+{% set title = 'Find and comment on an appeal' %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    html: 'Back to all prototypes',
+    href: '/#manage'
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">
+      Manage LPA appeals
+    </span>
+    <h1 class="govuk-heading-l">
+      {{ title }}
+    </h1>
+
+    {% set version = "5" %}
+
+    <h2 class="govuk-heading-m">
+      Version {{version}}
+      {{ govukTag({
+        classes: 'govuk-tag--yellow govuk-!-margin-left-2',
+        text: 'In progress'
+      }) }}
+    </h2>
+
+    <p class="govuk-body">
+      Changes:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>moved the work to the new prototype (<a href="https://pins-appeals.herokuapp.com/interested-party/v4/guidance" class="govuk-link govuk-link--no-visited-state">see version 4</a>)</li>
+      <li>Updates to follow…</li>
+    </ul>
+
+    {{ govukButton({
+      html: 'View prototype',
+      href: 'v'+version+'/guidance',
+      isStartButton: true
+    }) }}
+
+    {% set lpaForm %}
+
+      <form method="get" action="v{{version}}/guidance">
+
+        {{ govukInput({
+          id: 'dashboard-lpa',
+          name: 'dashboard-lpa',
+          value: data['dashboard-lpa'],
+          label: {
+            html: 'LPA&rsquo;s name'
+          },
+          spellcheck: false
+        }) }}
+
+        {{ govukInput({
+          id: 'lpa-email',
+          name: 'lpa-email',
+          value: data['lpa-email'],
+          label: {
+            html: 'LPA&rsquo;s email'
+          },
+          spellcheck: false
+        }) }}
+
+        {{ govukInput({
+          id: 'user-account',
+          name: 'users[0][email]',
+          value: data['users']['0']['email'],
+          label: {
+            html: 'Admin account email'
+          },
+          spellcheck: false
+        }) }}
+
+        {{ govukButton({
+          text: 'Add to URL',
+          classes: 'govuk-!-margin-bottom-0'
+        }) }}
+
+      </form>
+    {% endset -%}
+
+    {{ govukDetails({
+      summaryHtml: 'Change LPA details',
+      html: lpaForm
+    }) }}
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/_layout.html
+++ b/app/views/appeal/find-appeal/v5/_layout.html
@@ -1,0 +1,27 @@
+{% extends "layout.html" %}
+
+{% set bodyClasses = bodyClasses | default("internal") %}
+{% set serviceName = '<span class="dept">Planning Inspectorate</span> Manage your planning inspectorate appeals' | safe %}
+{% block pageTitle %}
+  Manage your planning inspectorate appeals — Planning Inspectorate
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters govuk-grid-column-two-thirds-from-desktop">
+
+      <form method="post">
+
+        {% block questions %}{% endblock %}
+
+        {% block buttons %}
+          {{ govukButton({
+            text: 'Continue'
+          }) }}
+        {% endblock %}
+
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/_routes.js
+++ b/app/views/appeal/find-appeal/v5/_routes.js
@@ -1,0 +1,27 @@
+const express = require('express')
+const router = new express.Router()
+
+router.get('*', function(req, res, next){
+  // Change the service name for this feature
+  res.locals['serviceName'] = 'Find and comment on planning appeals'
+  next()
+})
+
+router.post('/guidance', function (req, res) {
+  res.redirect('find-appeal')
+})
+
+router.post('/find-appeal', function (req, res) {
+  if (req.session.data['appeal-number'] == 'appealNumber') {
+    res.redirect('appeal-search-number')
+  } else {
+    res.redirect('appeal-search-postcode')
+  }
+})
+
+router.post('/documents-upload', function (req, res) {
+  res.redirect('check-your-answers')
+})
+
+// Add your routes above the module.exports line
+module.exports = router

--- a/app/views/appeal/find-appeal/v5/appeal-comment-email.html
+++ b/app/views/appeal/find-appeal/v5/appeal-comment-email.html
@@ -1,0 +1,73 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set title = "What’s your email address?" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+      <!-- if you are checking your answers -->
+      {% if data['checking'] %}
+        <form action="check-answers" method="post">
+      {% else %}
+        <form action="comment-upload" method="post">
+      {% endif %}
+
+        <span class="govuk-caption-l">{{ subServiceName }}</span>
+
+        <div class="govuk-form-group">
+
+          <label class="govuk-label govuk-label--l" for="postcode">
+            {{ title }}
+          </label>
+
+          <p class="govuk-body">
+            We’ll contact you if we need to discuss your comments.
+          </p>
+
+          <div class="govuk-form-group">
+
+            <input class="govuk-input" id="email" name="email" type="text" spellcheck="false" autocomplete="email" value="{{ data['email'] }}"></div>
+
+          </div>
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+
+      <!-- <h2 class="govuk-heading-m">
+        Don’t want to do it like this?
+      </h2>
+
+      <p class="govuk-body">
+        You can send your comments for this appeal to <a href="appeal-comment-name" class="govuk-link govuk-link--no-visited-state">
+          appealsmailbox@planninginspectorate.gov.uk
+        </a>
+      </p> -->
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/appeal-comment-name.html
+++ b/app/views/appeal/find-appeal/v5/appeal-comment-name.html
@@ -1,0 +1,65 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set subServiceName = "Comment on an appeal" %}
+
+{% set title = "What’s your full name?" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+      <!-- if you are checking your answers -->
+      {% if data['checking'] %}
+        <form action="check-answers" method="post">
+      {% else %}
+        <form action="appeal-comment-email" method="post">
+      {% endif %}
+
+        <span class="govuk-caption-l">{{ subServiceName }}</span>
+
+        <div class="govuk-form-group">
+
+          <label class="govuk-label govuk-label--l" for="postcode">
+            {{ title }}
+          </label>
+
+          <p class="govuk-body">
+            We need to know who’s commenting on the appeal.
+          </p>
+
+          <div class="govuk-form-group">
+
+            <input class="govuk-input" id="full-name" name="full-name" type="text" spellcheck="false" autocomplete="name" value="{{ data['full-name'] }}"></div>
+
+          </div>
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/appeal-decision.html
+++ b/app/views/appeal/find-appeal/v5/appeal-decision.html
@@ -1,0 +1,189 @@
+Aubrey{% extends "layout.html" %}
+
+{% set pageref = "###" %}
+{% extends "layout.html" %}
+
+{% set serviceName = "Appeal a planning decision" %}
+{% set subServiceName = "" %}
+
+{% if data['appealCode'] != "true" %}
+  {% set appealCode = "0166327" %}
+{% endif %}
+
+{% if data['appealCode'] %}
+  {% set title = "Appeal "+data['appealCode']+" decision" %}
+{% else %}
+  {% set title = "Appeal 0166327 decision" %}
+{% endif %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <span class="govuk-caption-l">{{ subServiceName }}</span>
+      <h1 class="govuk-heading-l">
+        {{ title }}
+      </h1>
+
+      <dl class="govuk-summary-list">
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Appeal site
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p>
+              {% if data['site-address'] %}
+                {{ data['site-address'] }}
+              {% else %}
+                2 Aubrey House, Aubrey Road, BS3 3EX
+              {% endif %}
+            </p>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key ">
+            Applicant
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if data['appellantName'] %}
+              {{ data['appellantName'] }}
+            {% else %}
+              J. M. Wigstone
+            {% endif %}
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-summary-list__key--no-border govuk-!-width-one-third">
+            Description of development
+          </dt>
+          <dd class="govuk-summary-list__value govuk-summary-list__value--no-border">
+            Loft conversion of roof to existing dwelling (Certificate of Lawfulness of Proposed Use).
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-summary-list__key--no-border govuk-!-width-one-third">
+            Local planning department
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Bristol City Council
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Inspector
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p>
+              C J Agenue BA (Hons) BTP MRTPI
+            </p>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Decision date
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p>
+              2 February 2022
+            </p>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row pins-summary-list__row--last">
+          <dt class="govuk-summary-list__key">
+            Decision issued
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p>
+              Allowed
+            </p>
+          </dd>
+        </div>
+
+      </dl>
+
+      <h2 class="govuk-heading-m">
+        Peliminary matters
+      </h2>
+
+      <p class="govuk-body">
+        The description of the proposed development in the header above is taken from the original application form. However, in dealing with the application, the Council described the proposal as “Proposed two storey side extension to create new dwelling”. In the interests of clarity, the appeal has been determined on the basis of the Council’s description.
+      </p>
+
+      <p class="govuk-body">
+        A revised version of the National Planning Policy Framework (the Framework) was published in July 2021 and the main parties were given the opportunity to submit comments. The 2021 version of the Framework is referred to in the decision.
+      </p>
+
+      <h2 class="govuk-heading-m">
+        Main issue
+      </h2>
+
+      <p class="govuk-body">
+        The main issue is the effect of the proposed development on the character and appearance of the host property and the wider area.
+      </p>
+
+      <h2 class="govuk-heading-m">
+        Reasons
+      </h2>
+
+      <ol class="govuk-list govuk-list--number">
+
+        <li>
+          The appeal site and 2 Aubrey House, Aubrey Road occupy a highly prominent street corner position alongside the junction of Aubrey Road with Chessel Street, which forms part of a crossroads. As the common boundary between the two properties has a diagonal alignment from the street corner, each has a triangular shaped plot.
+        </li>
+
+        <li>
+          In the original design of the appeal site and the neighbouring development on the north side of Aubrey Road, the built form distinctly comprised of modest two storey semi-detached houses with perpendicular external walls. As corner plot properties, the appeal site and No 2 were afforded particularly wide side gardens alongside the junction, as were Aubrey House and 1 Aubrey Road on the other street corner. Consequently, as a group, the side gardens would have created a very spacious entrance to Aubrey Road.
+        </li>
+
+        <li>
+          Over time, this spaciousness has been reduced by the development of detached infill properties in the side gardens of No 159 and No 1, (numbered 159A Aubrey Road and 1A Chessel Street respectively). It has also been reduced at the appeal site through the construction of a sizeable two storey side extension and an adjoining single storey garage. However, despite these significant changes, an important sense of spaciousness has been maintained alongside the junction, largely due to the front corners of the two storey elements at 159A and the appeal site being kept a good distance back from the side boundaries.
+        </li>
+
+        <li>
+          In the proposed scheme, the front corner of the two storey element would be positioned closer to the side boundary than at present, the existing open area above the garage would be lost, and a single storey side extension would further reduce the size and width of the side garden. Consequently, the remaining important sense of spaciousness alongside the junction would be harmfully eroded. Furthermore, in responding to the restriction imposed by the diagonal alignment of the side boundary, part of the flank wall to the two storey element would adopt an irregular angle. This would be a stark departure from the characteristic perpendicular walls to the main part of the dwellings in the area, and it would result in the property having an awkward and cramped appearance within its plot. While part of the flank wall to the existing garage adopts the same angle, its less prominent single storey height and ancillary form is distinguishable in this regard.
+        </li>
+
+        <li>
+          The proposed scheme would also result in the host property, which has already been greatly extended to the side, in having an over-extended and unbalanced appearance, both in its own right and set against the modest proportions of the attached neighbouring dwelling. While the appellants have suggested the scheme would lead to the appearance of a terrace, its significant width would be incongruous amongst the distinctive neighbouring semi-detached properties and later infill detached houses. Furthermore, in the nearby terraces that are found on Aubrey Road, the constituent properties have a common and harmonious design, whereas in the appeal development they would be individual and disjointed.
+        </li>
+
+        <li>
+          The proposed planting to the front and the side garden, including some small trees, would fail to successfully mitigate the aforementioned harm to the host property and the street scene. Moreover, notwithstanding the fact the scheme would respect the roof design and the materials of the host and other properties in the locality, it would not represent a visual improvement over the existing garage and side garden arrangement.
+        </li>
+
+        <li>
+          The appellants have drawn attention to an existing side extension at 3 Aubrey House. However, it appears to be of a similar, if not smaller scale to the existing extensions at the appeal site. Moreover, it was considered against a different planning policy context and does not occupy a highly prominent position alongside a crossroads. It is therefore not directly comparable and it does not justify the harm that would arise from the appeal scheme which has been considered on its own merits and with regard to its particular location and circumstances.
+        </li>
+
+      </ol>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/appeal-details.html
+++ b/app/views/appeal/find-appeal/v5/appeal-details.html
@@ -1,0 +1,205 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+
+{% if data['appealCode'] != "true" %}
+  {% set appealCode = "0166327" %}
+{% endif %}
+
+{% set title = "Appeal "+data['appealCode'] %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <span class="govuk-caption-l">{{ subServiceName }}</span>
+      <h1 class="govuk-heading-l">
+        {{ title }}
+      </h1>
+    </div>
+
+    <div class="govuk-grid-column-full">
+      {% if data['status'] == "open" %}
+        <!-- comments are open -->
+        <section class="govuk-!-margin-bottom-3">
+          <strong class="govuk-tag govuk-tag--blue">
+            Open for comments
+          </strong>
+        </section>
+
+        <p class="govuk-body">
+          You can comment on this appeal until 11:59pm on 4 May 2022.
+        </p>
+
+      {% elseif data['status'] == "closed" %}
+        <!-- closed / can not comment -->
+        <section class="govuk-!-margin-bottom-3">
+          <strong class="govuk-tag govuk-tag--green">
+            Closed for comments
+          </strong>
+        </section>
+
+        <p class="govuk-body">
+          The deadline for comments was 4 January 2022. You cannot add comments.
+        </p>
+
+      {% else %}
+        <!-- closed / decision made -->
+        <section class="govuk-!-margin-bottom-3">
+          <strong class="govuk-tag govuk-tag--black">
+            Decision made
+          </strong>
+        </section>
+      {% endif %}
+
+      <dl class="govuk-summary-list">
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Appeal site
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p>
+              {% if data['site-address'] %}
+                {{ data['site-address'] }}
+              {% else %}
+                2 Aubrey House, Aubrey Road, BS3 3EX
+              {% endif %}
+            </p>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key ">
+            Applicant
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if data['appellantName'] %}
+              {{ data['appellantName'] }}
+            {% else %}
+              J. M. Wigstone
+            {% endif %}
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-summary-list__key--no-border govuk-!-width-one-third">
+            Description of development
+          </dt>
+          <dd class="govuk-summary-list__value govuk-summary-list__value--no-border">
+            Loft conversion of roof to existing dwelling (Certificate of Lawfulness of Proposed Use).
+            <p class="govuk-body">
+              <a href="https://www.bristol.gov.uk/planning-and-building-regulations" target="_blank">
+                View the application details on the local planning department’s website (opens in new tab)
+              </a>
+            </p>
+          </dd>
+        </div>
+
+        {% if data['status'] != "completed" %}
+          <div class="govuk-summary-list__row pins-summary-list__row--last">
+        {% else %}
+          <div class="govuk-summary-list__row">
+        {% endif %}
+
+          <dt class="govuk-summary-list__key govuk-summary-list__key--no-border govuk-!-width-one-third">
+            Local planning department
+          </dt>
+          <dd class="govuk-summary-list__value govuk-summary-list__value--no-border">
+            Bristol City Council
+          </dd>
+        </div>
+
+        {% if data['status'] == "completed" %}
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key govuk-summary-list__key--no-border govuk-!-width-one-third">
+              Decision issued
+            </dt>
+            <dd class="govuk-summary-list__value govuk-summary-list__value--no-border">
+              {% if data['decision'] == "allowed" %}
+                Allowed
+              {% elseif data['decision'] == "disallowed" %}
+                Disallowed
+              {% elseif data['decision'] == "split" %}
+                Split decision
+              {% elseif data['decision'] == "invalid" %}
+                Invalid
+              {% else %}
+                Allowed
+              {% endif %}
+
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row pins-summary-list__row--last">
+            <dt class="govuk-summary-list__key govuk-summary-list__key--no-border govuk-!-width-one-third">
+              Decision date
+            </dt>
+            <dd class="govuk-summary-list__value govuk-summary-list__value--no-border">
+              2 February 2022
+            </dd>
+          </div>
+
+          <!-- <div class="govuk-summary-list__row pins-summary-list__row--last">
+            <dt class="govuk-summary-list__key govuk-summary-list__key--no-border govuk-!-width-one-third">
+              Decision document
+            </dt>
+            <dd class="govuk-summary-list__value govuk-summary-list__value--no-border">
+              <a href="#">
+                See the appeal decision
+              </a>
+            </dd>
+          </div> -->
+
+        {% endif %}
+
+      </dl>
+
+      {% if data['status'] == "completed" %}
+        <p class="govuk-body">
+          View the decision document for this appeal<br>
+          <a href="{{ asset_path }}files/blank.pdf">
+             Decision-letter-0166327.pdf
+          </a>
+        </p>
+      {% endif %}
+
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if data['status'] == "open" %}
+
+        <!-- user can comment -->
+        {{ govukButton({
+          text: "Comment on this appeal",
+          classes: "govuk-!-margin-bottom-9",
+          href: "appeal-comment-name?checking="
+        }) }}
+
+      {% endif %}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/appeal-search-no-results.html
+++ b/app/views/appeal/find-appeal/v5/appeal-search-no-results.html
@@ -1,0 +1,60 @@
+{% set pageref = "###" %}
+{% extends "layout.html" %}
+
+{% set serviceName = "Find out about planning appeals" %}
+
+{% set title = "No matching appeals" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      {{ title }}
+    </h1>
+
+    {% if data['search'] == "number" %}
+      <p class="govuk-body">
+        No appeals found using that appeal reference.
+      </p>
+    {% else %}
+      <p class="govuk-body">
+        {% if data['postcode'] %}
+          No appeals found for {{ data['postcode'] }}. <a href="appeal-search-address?version=" class="govuk-link">Change<span class="govuk-visually-hidden"> search address</span></a>
+        {% else %}
+          No appeals found for BS3 3EX.
+        {% endif %}
+      </p>
+    {% endif %}
+
+    {% if data['search'] == "number" %}
+      <a href="appeal-search-reference" class="govuk-link">
+    {% else %}
+      <a href="appeal-search-address" class="govuk-link">
+    {% endif %}
+      Search for another appeal
+    </a>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/appeal-search-number.html
+++ b/app/views/appeal/find-appeal/v5/appeal-search-number.html
@@ -1,0 +1,64 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set title = "Enter the appeal reference" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+      <form action="appeal-details?status=open" method="post">
+
+        <div class="govuk-form-group">
+
+          <label class="govuk-label govuk-label--l" for="postcode">
+            {{ title }}
+          </label>
+
+          <p class="govuk-body">
+            This can be found on the letter you received from the local planning department. If you did not receive a letter, you can find the appeal reference on the local planning department’s website.
+          </p>
+
+          <p class="govuk-hint">
+            For example, 0166327.
+          </p>
+
+          <input class="govuk-input govuk-input--width-10" id="appealCode-input" name="appealCode" type="number">
+
+        </div>
+
+        <p class="govuk-body">
+          <a href="appeal-search-postcode?version=">
+            Search for an appeal using a postcode
+          </a>
+        </p>
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/appeal-search-postcode.html
+++ b/app/views/appeal/find-appeal/v5/appeal-search-postcode.html
@@ -1,0 +1,78 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set title = "Search for an appeal using a postcode" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form action="open-appeals?version=" method="post">
+
+      <div class="govuk-form-group">
+
+        <label class="govuk-label govuk-label--l" for="postcode">
+          {{ title }}
+        </label>
+
+        <p class="govuk-hint">
+          For example, BS1 6PN
+        </p>
+
+        {% if data['postcode'] %}
+          <input class="govuk-input govuk-input--width-5" id="postcode-input" name="postcode" type="text" value="{{ data['email'] }}">
+        {% else %}
+          <input class="govuk-input govuk-input--width-5" id="postcode-input" name="postcode" type="text">
+        {% endif %}
+
+      </div>
+
+      {% if data['version'] == "address-filter" %}
+
+        <div class="govuk-form-group govuk-!-margin-bottom-6">
+
+          <label class="govuk-label" for="postcode">
+            House number or name (optional)
+          </label>
+
+          <input class="govuk-input govuk-input--width-20" id="postcode-input" name="postcode" type="text">
+
+        </div>
+
+      {% endif %}
+
+      <p class="govuk-body">
+        <a href="appeal-search-reference?version=">
+          Search for an appeal using the appeal reference
+        </a>
+      </p>
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/check-answers.html
+++ b/app/views/appeal/find-appeal/v5/check-answers.html
@@ -1,0 +1,111 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set title = "Check your answers" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service - your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        {{ title }}
+      </h1>
+
+    </div>
+    <div class="govuk-grid-column-full">
+
+      <!-- <h2 class="govuk-heading-m">Your comment</h2> -->
+
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Name
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['full-name'] or "Sam Phipps"}}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="appeal-comment-name?checking=1">
+              Change<span class="govuk-visually-hidden"> name</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Email address
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['email'] or "samphips@email.com" }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="appeal-comment-email?checking=1">
+              Change<span class="govuk-visually-hidden"> address</span>
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row pins-summary-list__row--last">
+          <dt class="govuk-summary-list__key">
+            Comments
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-body">
+              {% if data['comments'] %}
+                {% set i = 0 %}
+                {% for file in data['comments'] %}
+                  {% set i = i + 1 %}
+                    {{ file }}<br>
+                {% endfor %}
+              {% else %}
+                Appeal comments.txt
+              {% endif %}
+            </p>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="comment-upload?checking=1">
+              Change<span class="govuk-visually-hidden"> contact details</span>
+            </a>
+          </dd>
+        </div>
+      </dl>
+
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-m">
+        Now send your comments
+      </h2>
+
+      <p class="govuk-body">
+        By sending your comments, you are confirming that, to the best of your knowledge, the details you are providing are correct.
+      </p>
+
+      {{ govukButton({
+        text: "Accept and send",
+        href: "comment-received"
+      }) }}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/closed-appeals.html
+++ b/app/views/appeal/find-appeal/v5/closed-appeals.html
@@ -1,0 +1,247 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set title = "Completed appeals" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      {% if data['postcode'] %}
+        33 completed appeals found for {{ data['postcode'] }}
+      {% else %}
+        33 completed appeals found for BS3 3EX
+      {% endif %}
+    </h1>
+
+    <p class="govuk-body govuk-!-margin-bottom-6">
+       Select an appeal to go to the decision.
+     </p>
+
+  </div>
+
+  <!-- main table -->
+  <div class="govuk-grid-column-full">
+
+  {{ govukTable({
+    caption: "1 to 10 of completed appeals",
+    captionClasses: "govuk-table__caption--m",
+
+    head: [
+
+      {
+        text: "Appeal site",
+        classes: 'govuk-!-width-one-third'
+      },
+      {
+        text: "Applicant",
+        classes: 'govuk-!-width-one-quarter'
+      },
+      {
+        text: "Appeal reference",
+        format: 'numeric'
+      },
+      {
+        text: "Decision date",
+        classes: 'govuk-!-width-one-quarter',
+        format: 'numeric'
+      }
+    ],
+    rows: [
+      [
+        {
+          text: "102 Aubrey Road, BS3 3EX"
+        },
+        {
+          text: "Mel Pickins"
+        },
+        {
+          html: '<a class="govuk-link" href="appeal-details?status=completed&appealCode=0166002&site-address=102%20Aubrey%20Road%2C%20BS3%203EX&appellantName=Mel%20Pickins">0166002</a>',
+          format: 'numeric'
+        },
+        {
+          text: "21 January 2022",
+          format: 'numeric'
+        }
+      ],
+      [
+        {
+          text: "77 Aubrey Road, BS3 3EX"
+        },
+        {
+          text: "Nic Soonez"
+        },
+        {
+          html: '<a class="govuk-link" href="appeal-details?status=completed&appealCode=0141289&site-address=77%20Aubrey%20Road%2C%20BS3%203EX&appellantName=Nic%20Soonez">0141289</a>',
+          format: 'numeric'
+        },
+        {
+          text: "21 January 2022",
+          format: 'numeric'
+        }
+      ],
+      [
+        {
+          text: "19 Aubrey Road, BS3 3EX"
+        },
+        {
+          text: "Talisan Creedance"
+        },
+        {
+          html: '<a class="govuk-link" href="appeal-details?status=completed&appealCode=0165971&site-address=19%20Aubrey%20Road%2C%20BS3%203EX&appellantName=Talisan%20Creedance">0165971</a>',
+          format: 'numeric'
+        },
+        {
+          text: "12 January 2022",
+          format: 'numeric'
+        }
+      ],
+      [
+        {
+          text: "2 Aubrey House, Aubrey Road, BS3 3EX"
+        },
+        {
+          text: "J. M. Wigstone"
+        },
+        {
+          html: '<a class="govuk-link" href="appeal-details?status=completed&appealCode=0165791&site-address=2%20Aubrey%20House%2C%20Aubrey%20Road%2C%20BS3%203EX&appellantName=J.%20M.%20Wigstone">0165791</a>',
+          format: 'numeric'
+        },
+        {
+          text: "20 December 2021",
+          format: 'numeric'
+        }
+      ],
+
+      [
+        {
+          text: "1 Aubrey House, Aubrey Road, BS3 3EX"
+        },
+        {
+          text: "Jan Fish"
+        },
+        {
+          html: '<a class="govuk-link" href="appeal-details?status=completed&appealCode=0166241&site-address=1%20Aubrey%20House%2C%20Aubrey%20Road%2C%20BS3%203EX&appellantName=Jan%20Fish">0166241</a>',
+          format: 'numeric'
+        },
+        {
+          text: "11 July 2021",
+          format: 'numeric'
+        }
+      ],
+      [
+        {
+          text: "22 Aubrey Road, BS3 3EX"
+        },
+        {
+          text: "P. J. Thames"
+        },
+        {
+          html: '<a class="govuk-link" href="appeal-details?status=completed&appealCode=0166111&site-address=22%20Aubrey%20Road%2C%20BS3%203EX&appellantName=P.%20J.%20Thames">0166111</a>',
+          format: 'numeric'
+        },
+        {
+          text: "13 June 2021",
+          format: 'numeric'
+        }
+      ],
+      [
+        {
+          text: "155 Aubrey Road, BS3 3EX"
+        },
+        {
+          text: "Danny Fiakkas"
+        },
+        {
+          html: '<a class="govuk-link" href="appeal-details?status=completed&appealCode=0166102&site-address=155%20Aubrey%20Road%2C%20BS3%203EX&appellantName=Danny%20Fiakkas">0166102</a>',
+          format: 'numeric'
+        },
+        {
+          text: "13 April 2021",
+          format: 'numeric'
+        }
+      ],
+      [
+        {
+          text: "32 Vicarage Court, Aubrey Road, BS3 3EX"
+        },
+        {
+          text: "Pavarthi Sagar"
+        },
+        {
+          html: '<a class="govuk-link" href="appeal-details?status=completed&appealCode=0165854&site-address=32%20Vicarage%20Court%2C%20Aubrey%20Road%2C%20BS3%203EX&appellantName=Pavarthi%20Sagar">0165854</a>',
+          format: 'numeric'
+        },
+        {
+          text: "13 April 2021",
+          format: 'numeric'
+        }
+      ],
+      [
+        {
+          text: "8 Aubrey Road, BS3 3EX"
+        },
+        {
+          text: "Ash Davenant"
+        },
+        {
+          html: '<a class="govuk-link" href="appeal-details?status=completed&appealCode=0165921&site-address=8%20Aubrey%20Road%2C%20BS3%203EX&appellantName=Ash%20Davenant">0165921</a>',
+          format: 'numeric'
+        },
+        {
+          text: "8 March 2021",
+          format: 'numeric'
+        }
+      ],
+      [
+        {
+          text: "1 Vicarage Court, Aubrey Road, BS3 3EX"
+        },
+        {
+          text: "Charlie Agadosi"
+        },
+        {
+          html: '<a class="govuk-link" href="appeal-details?status=completed&appealCode=0166013&site-address=1%20Vicarage%20Court%2C%20Aubrey%20Road%2C%20BS3%203EX&appellantName=Charlie%20Agadosi">0166013</a>',
+          format: 'numeric'
+        },
+        {
+          text: "18 February 2021",
+          format: 'numeric'
+        }
+      ]
+    ]
+  }) }}
+
+  <ul class="govuk-list">
+    <li>
+      <!-- <p class="govuk-body-l"> -->
+        <a class="govuk-link" href="#">
+          Next 10 closed appeals
+        </a>
+      <!-- </p> -->
+    </li>
+  </ul>
+
+</div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/comment-delete.html
+++ b/app/views/appeal/find-appeal/v5/comment-delete.html
@@ -1,0 +1,114 @@
+{% extends "layout.html" %}
+
+{% set serviceName = "Find out about planning appeals" %}
+
+{% set title = "Delete a comment" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        {{ title }}
+      </h1>
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Filename</th>
+            <th scope="col" class="govuk-table__header"></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td scope="row" class="govuk-table__cell">
+              <a href="javascript:peventDefault();">
+                {{ data['comments'][data['row']-1] }}
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h2 class="govuk-fieldset__heading">
+              Are you sure?
+            </h2>
+          </legend>
+          <div class="govuk-checkboxes govuk-checkboxes--small">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="areyousure" name="areyousure" type="checkbox" value="delete">
+              <label class="govuk-label govuk-checkboxes__label" for="areyousure">
+                Yes, I want to delete this comment
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <form action="" method="post">
+
+        <input type="hidden" name="deleterow" id ="deleterow" value="{{ data['row']-1 }}">
+
+        {{ govukButton({
+          text: "Delete",
+          disabled: true,
+          classes: "govuk-!-margin-right-5"
+        }) }}
+
+        {{ govukButton({
+          href: "/standalone/as-2078/supplementary-list",
+          text: "Cancel",
+          classes: "govuk-button--secondary"
+        }) }}
+
+      </form>
+
+    </div>
+
+  </div>
+
+  <!-- End of content -->
+
+{% endblock %}
+
+<!-- DO NOT enter page content after the above block -->
+
+{% block pageScripts %}
+
+	<script>
+    $( "#areyousure" ).on( "change", function() {
+      var $this = $(".govuk-button");
+      if ($this.hasClass('govuk-button--disabled')) {
+        $this.removeAttr('disabled');
+        $this.removeClass('govuk-button--disabled');
+      } else {
+        $this.attr('disabled', 'disabled');
+        $this.addClass('govuk-button--disabled');
+      }
+    });
+  </script>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/comment-received.html
+++ b/app/views/appeal/find-appeal/v5/comment-received.html
@@ -1,0 +1,76 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set title = "Comment received" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <section class="govuk-!-margin-bottom-9">
+
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title">
+          {{ title }}
+        </h1>
+
+
+
+        <div class="govuk-panel__body govuk-!-margin-bottom-3">
+          Your comment will be included in the appeal.
+        </div>
+
+        <div class="govuk-panel__body">
+          Appeal reference: <strong>
+            {% if data['appealCode'] %}
+              {{ data['appealCode'] }}
+            {% else %}
+              0166327
+            {% endif %}
+            </strong>
+        </div>
+      </div>
+
+      <p class="govuk-body">We have sent you a confirmation email.</p>
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+
+      <p class="govuk-body">
+        Your comments will be shared with the applicant and Bristol City Council.
+      </p>
+
+      <p class="govuk-body">
+        The Inspector will review them when determining the appeal.
+      </p>
+
+      <!-- <p class="govuk-body">
+        We will contact you again when a decision is made.
+      </p> -->
+
+      <!-- <p class="govuk-body">
+        A decision is expected by 27 May 2022.
+      </p> -->
+
+    </section>
+
+    <p class="govuk-body">
+      <a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/comment-upload-list.html
+++ b/app/views/appeal/find-appeal/v5/comment-upload-list.html
@@ -1,0 +1,74 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set title = "Your uploaded comments"  %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form action="check-answers" method="post">
+
+        <h1 class="govuk-heading-l">
+          {{ title }}
+        </h1>
+
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">File name</th>
+              <th scope="col" class="govuk-table__header"></th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            {% set i = 0 %}
+            {% for file in data['comments'] %}
+              {% set i = i + 1 %}
+              <tr class="govuk-table__row">
+                <td scope="row" class="govuk-table__cell"><a href="javascript:peventDefault();">{{ file }}</a></td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">
+                  <a class="govuk-link" href="/interested-party/v3/comment-delete?row={{ i }}">
+                    Delete<span class="govuk-visually-hidden"> {{ file }}</span>
+                  </a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+
+        <div class="govuk-button-group">
+          <a href="comment-upload" class="govuk-button govuk-button--secondary">
+            Add another
+          </a>
+
+          {{ govukButton({
+            text: "Continue"
+          }) }}
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/comment-upload.html
+++ b/app/views/appeal/find-appeal/v5/comment-upload.html
@@ -1,0 +1,79 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set title = "Upload your comments"  %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <!-- <form action="comment-upload-list" method="post"> -->
+      <form action="comment-upload-list" method="post" novalidate>
+
+        <h1 class="govuk-heading-l">
+          {{ title }}
+        </h1>
+
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="upload-multiple">
+            Drag and drop or choose files
+          </label>
+          <input class="govuk-file-upload pins-file-upload" id="comments-file" name="comments-file" type="file" multiple>
+        </div>
+
+        {{ govukDetails({
+          summaryText: "Files you can upload",
+          html: '
+            <p class="govuk-body">
+              You can upload the following types of file:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>RTF</li>
+              <li>TXT</li>
+              <li>DOC</li>
+              <li>DOCX</li>
+              <li>PDF</li>
+              <li>DOC or DOCX</li>
+              <li>JPG or JPEG</li>
+              <li>PDF</li>
+              <li>PNG</li>
+              <li>TIF or TIFF</li>
+            </ul>
+
+            <p>
+              Your file must be smaller than 15MB.
+            </p>
+
+          '
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/comments-received-confirmation.html
+++ b/app/views/appeal/find-appeal/v5/comments-received-confirmation.html
@@ -1,0 +1,66 @@
+{% extends "layout-email.html" %}
+
+{% block pageTitle %}
+  Interested party full planning notification
+{% endblock %}
+
+
+Dear [IP NAME]Site detailsSite Address:[INSERT HERE]Description of development:[INSERT HERE]Application reference:[INSERT HERE]An appeal has been made against the decision of [LPD]to [insert reason for appeal, i.e. refuse to grant planning permission].[The appeal will be determined on the basis of written representations.][The appeal will be determined on the basis of a hearing.] [The appeal will be determined on the basis of an inquiry.] Interested individuals that want to take part in the Inquiry can do so by applying for Rule 6 status.Rule 6 status means that you would be able to present your evidence on a formal basis and cross examine the evidence of others.You can learn more about Rule 6 at:https://www.gov.uk/government/publications/apply-for-rule-6-status-on-a-planning-appeal-or-called-in-applicationWhat happens next** TO BE ADDED **Thank you,The Planning Inspectorate
+
+
+
+{% block content %}
+<p><strong>Subject:</strong> We’ve received your comments for appeal APP/Q999/O/21/0166327</p>
+<p><strong>From:</strong> planningappeals@bristolcitycouncil.gov.uk</p>
+
+<!-- <img src="{{ asset_path }}images/pi-logo.png" width="150"/> -->
+
+<hr>
+
+<div class="govuk-grid-row govuk-!-margin-top-5">
+  <div class="govuk-grid-column-two-thirds">
+
+    <!-- <p class="govuk-body">Planning appeal reference: A/1234567</p> -->
+    <p class="govuk-body">Dear [name],</p>
+    <!-- <p class="govuk-body">We’ve started a full appeal against the refusal of planning application <strong>A/10112454</strong>.</p> -->
+
+    <p class="govuk-body">
+      Your comments have been received.
+    </p>
+
+    <p class="govuk-body">
+      <strong>Appeal reference:</strong><br>
+      0166327
+    </p>
+
+    <p class="govuk-body">
+      <strong>Appeal site:</strong><br>
+      1 Aubrey House
+      Aubrey Road
+      Bristol BS3 3EX
+    </p>
+
+    <h2 class="govuk-heading-m">
+      What happens next
+    </h2>
+
+    <p class="govuk-body">
+      Your comments will be shared with the applicant and local planning department.
+    </p>
+
+    <p class="govuk-body">
+      An Inspector will review them when determining the appeal.
+    </p>
+
+    <p class="govuk-body">
+      When a decision is made, it will be published online at <a href="https://www.bristol.gov.uk/planning-and-building-regulations/search-and-track-planning-applications">https://www.bristol.gov.uk/planning-and-building-regulations/search-and-track-planning-applications</a>
+    </p>
+
+    <p class="govuk-body">
+      From,​<br>
+      Bristol City Council Planning Department<br>
+    </p>
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/find-appeal.html
+++ b/app/views/appeal/find-appeal/v5/find-appeal.html
@@ -1,0 +1,72 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set title = "How do you want to search for an appeal?" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form method="post">
+
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" aria-describedby="appeal-number-hint">
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                {{ title }}
+              </h1>
+            </legend>
+
+            <div class="govuk-radios" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="appeal-number" name="appeal-number" type="radio" value="appealNumber" aria-describedby="appeal-number-item-hint">
+                <label class="govuk-label govuk-radios__label" for="appeal-number">
+                  With an appeal reference
+                </label>
+                <div id="appeal-number-item-hint" class="govuk-hint govuk-radios__hint">
+                  This can be found on the letter you received from the local planning department. If you did not receive a letter, you can find the appeal reference on the local planning department's website.
+                </div>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="appeal-number-2" name="appeal-number" type="radio" value="appealAddress" aria-describedby="appeal-number-2-item-hint">
+                <label class="govuk-label govuk-radios__label" for="appeal-number-2">
+                  With a postcode
+                </label>
+              </div>
+            </div>
+
+          </fieldset>
+        </div>
+
+        <button class="govuk-button" data-module="govuk-button">
+          Continue
+        </button>
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/guidance.html
+++ b/app/views/appeal/find-appeal/v5/guidance.html
@@ -1,0 +1,123 @@
+{% extends '_layouts/layout-main.html' %}
+<!-- {% set prototypeLinks = [{href: 'errors/certain-types', text: 'Advertisement and DN not included yet'}] %} -->
+
+{% set serviceName = "Find and comment on planning appeals" %}
+
+{% set title = "Guidance" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        {{ title }}
+      </h1>
+
+      <p class="govuk-body">
+        This is a service for searching, viewing and commenting on planning appeals.
+      </p>
+
+      <p class="govuk-body">
+        You can use this service to:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+
+        <li>
+          view appeals that are open for comments and submit your comments
+        </li>
+
+        <li>
+          view appeals that are closed for comments
+        </li>
+
+        <li>
+          view appeals that are complete and view the decision for those appeals
+        </li>
+
+      </ul>
+
+      <p class="govuk-body">
+        If you want to comment on an appeal, you'll need:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+
+        <li>
+          the 7-digit reference number that can be found on your letter from the local planning department. This can also be found on the local planning department's website
+        </li>
+
+        <li>
+          an email address so we can contact you if we have any questions
+        </li>
+
+        <li>
+          your comments saved in a document
+        </li>
+
+      </ul>
+
+      <h2 class="govuk-heading-m">
+        Guidance about your comments
+      </h2>
+
+      <p class="govuk-body">
+        Any previous comments that you submitted as part of an application will be considered by the Planning Inspector. The local planning department shares these with the Planning Inspectorate, so there is no need to submit repeat comments.
+      </p>
+
+      <p class="govuk-body">
+        You should avoid including sensitive information (also called special category information) if it's not relevant to the appeal. Any sensitive information you share may be shared publicly if the Planning Inspector agrees that it's relevant to your appeal.
+      </p>
+
+      <p>
+        Your comments must not include inflammatory or abusive language.
+      </p>
+
+      {% include "_includes/sensitive-information-list.html" %}
+
+
+      <!-- <p class="govuk-body">
+        If you include any personal information that's not relevant, we'll ask you to resubmit. This could mean that you miss the deadline to submit comments.
+      </p>
+
+      <p class="govuk-body">
+        Your comments must not include inflammatory or abusive language.
+      </p> -->
+
+      {{ govukButton({
+        href: "find-appeal",
+        text: "Continue"
+      }) }}
+
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block pageScripts %}
+  <script type="text/javascript" src="/public/javascripts/autocomplete/accessible-autocomplete.min.js"></script>
+  <script>
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement: document.querySelector('#appealsub-{{version}}-beforeyoustart-planningdepartment')
+    })
+  </script>
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/householder-appeal-first-notice-letter.html
+++ b/app/views/appeal/find-appeal/v5/householder-appeal-first-notice-letter.html
@@ -1,0 +1,131 @@
+{% extends "layout-email.html" %}
+
+{% block pageTitle %}
+  Interested party full planning notification
+{% endblock %}
+
+
+Dear [IP NAME]Site detailsSite Address:[INSERT HERE]Description of development:[INSERT HERE]Application reference:[INSERT HERE]An appeal has been made against the decision of [LPD]to [insert reason for appeal, i.e. refuse to grant planning permission].[The appeal will be determined on the basis of written representations.][The appeal will be determined on the basis of a hearing.] [The appeal will be determined on the basis of an inquiry.] Interested individuals that want to take part in the Inquiry can do so by applying for Rule 6 status.Rule 6 status means that you would be able to present your evidence on a formal basis and cross examine the evidence of others.You can learn more about Rule 6 at:https://www.gov.uk/government/publications/apply-for-rule-6-status-on-a-planning-appeal-or-called-in-applicationWhat happens next** TO BE ADDED **Thank you,The Planning Inspectorate
+
+
+
+{% block content %}
+
+<img src="{{ asset_path }}images/bcc-logo.png" width="150" class="govuk-!-margin-bottom-6" />
+
+<p>
+  Bristol City Council Planning Department, Atlas Buildings<br>
+  Sedgemore Road, Bristol BS1 6XN
+</p>
+
+<p class="govuk-!-margin-bottom-9">
+  <strong>[Your name]</strong><br>
+  Atlas Buildings<br>
+  Sedgemore Road<br>
+  Bristol<br>
+  BS1 6XN
+</p>
+
+<p class="govuk-body">
+  <strong>Appeal reference</strong><br>
+  0166327
+</p>
+
+<p class="govuk-body">
+  <strong>Appeal site</strong><br>
+  1 Aubrey House
+  Aubrey Road
+  Bristol BS3 3EX
+</p>
+
+<div class="govuk-grid-row govuk-!-margin-top-5">
+  <div class="govuk-grid-column-two-thirds">
+
+    <!-- <p class="govuk-body">Planning appeal reference: A/1234567</p> -->
+    <p class="govuk-body">Dear [Your name],</p>
+    <!-- <p class="govuk-body">We’ve started a full appeal against the refusal of planning application <strong>A/10112454</strong>.</p> -->
+
+    <p class="govuk-body">
+      J.M. Wigstone is appealing Bristol City Council's decision to refuse planning application A/10112454.
+    </p>
+
+    <p class="govuk-body">
+      Planning appeals are decided by the Planning Inspectorate.
+    </p>
+
+    <p class="govuk-body">
+      The Planning Inspectorate is an independent, impartial body that decides appeals on planning applications.
+    </p>
+
+    <p class="govuk-body">
+      The Planning Inspectorate makes a decision based on written statements from the applicant, Bristol City Council, and interested parties.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      What you can do
+    </h2>
+
+    <h3 class="govuk-heading-s">
+      Comment on the appeal
+    </h3>
+
+    <p class="govuk-body">
+      You can comment on the appeal until 11.59pm on 4 May 2022.
+    </p>
+
+    <p class="govuk-body">
+      We’ve already sent your original comments to the Inspector. You do not need to repeat this information again.
+    </p>
+
+    <p class="govuk-body">
+      You can submit any new comments to the Planning Inspectorate at https://www.gov.uk/appeal-planning-decision/comment-on-an-appeal/appeal-search
+    </p>
+
+    <p class="govuk-body">
+      You will need to enter the appeal reference: <strong>0166327</strong>.
+    </p>
+
+    <h3 class="govuk-heading-s">
+      Request a site visit
+    </h3>
+
+    <p class="govuk-body">
+      You can request for the Planning Inspector to view the appeal site from your property. You can request this by emailing enquiries@planninginspectorate.gov.uk
+    </p>
+
+    <h3 class="govuk-heading-s">
+      Withdraw comments
+    </h3>
+
+    <p class="govuk-body">
+      You can withdraw any comments you've made in the past. You can do this by emailing enquiries@planninginspectorate.gov.uk by 11.59pm on 4 May 2022.
+    </p>
+
+    <h3 class="govuk-heading-s">
+      View the appeal details
+    </h3>
+
+    <p class="govuk-body">
+      You can view the appeal details of the planning application at https://www.bristol.gov.uk/planning-and-building-regulations/search-and-track-planning-application
+    </p>
+
+    <h2 class="govuk-heading-m">
+      What happens next
+    </h2>
+
+    <p class="govuk-body">
+      The Planning Inspectorate will look at the evidence from the applicant and the local planning department, conduct a site visit, and make the final decision on the appeal.
+    </p>
+
+    <p class="govuk-body">
+      The Planning Inspectorate will publish the decision online at https://www.bristol.gov.uk/planning-and-building-regulations/search-and-track-planning-applications
+    </p>
+
+    <p class="govuk-body">
+      Thank you,​<br>
+      Bristol City Council Planning Department<br>
+    </p>
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/appeal/find-appeal/v5/open-appeals.html
+++ b/app/views/appeal/find-appeal/v5/open-appeals.html
@@ -1,0 +1,206 @@
+{% extends '_layouts/layout-main.html' %}
+
+{% set serviceName = "Find and comment on planning appeals" %}
+{% set title = "Appeals in progress at (postcode)" %}
+
+{% block pageTitle %}
+  {{ title }} - {{serviceName}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.go(-1);"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+{{ data['postcode'] }}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      {% if data['postcode'] %}
+        Appeals in progress at {{ data['postcode'] }}
+      {% else %}
+        Appeals in progress at BS3 3EX
+      {% endif %}
+    </h1>
+
+    <p class="govuk-body govuk-!-margin-bottom-6">
+      Select an appeal to go to the appeal details.
+    </p>
+
+    <!-- another pattern where the postcode and link to change it is called out more -->
+
+    <!-- <h1 class="govuk-heading-l">
+      Appeals in progress
+    </h1>
+
+    <section class="govuk-!-margin-bottom-9">
+      <p class="govuk-body">
+        {% if data['postcode'] %}
+          3 appeals found at {{ data['postcode'] }}.
+        {% else %}
+          3 appeals found at BS3 3EX.
+        {% endif %}
+      </p>
+
+      <p class="govuk-body">
+        <a href="appeal-search-address?version=" class="govuk-link">Search by a different postcode</a>
+      </p>
+    </section> -->
+
+    <h2 class="govuk-heading-m">
+      Open for comments
+    </h2>
+
+    <!-- <p class="govuk-body">
+      {% if data['postcode'] %}
+        3 open appeals found for {{ data['postcode'] }}.<br><a href="appeal-search-address?version=" class="govuk-link">Search by a different postcode</a>
+      {% else %}
+        3 open appeals found for BS3 3EX.<br><a href="appeal-search-address?version=" class="govuk-link">Search by a different postcode</a>
+      {% endif %}
+    </p> -->
+
+  </div>
+
+  <!-- main table -->
+  <div class="govuk-grid-column-full">
+
+    {{ govukTable({
+      caption: "Open appeals",
+      captionClasses: "govuk-table__caption--m govuk-visually-hidden",
+
+      head: [
+
+        {
+          text: "Appeal site",
+          classes: 'govuk-!-width-one-half'
+        },
+        {
+          text: "Applicant",
+          classes: 'govuk-!-width-one-quarter'
+        },
+        {
+          text: "Appeal reference",
+          classes: 'govuk-!-width-one-quarter',
+          format: "numeric"
+        }
+      ],
+      rows: [
+        [
+          {
+            text: "2 Aubrey House, Aubrey Road, Bristol BS3 3EX"
+          },
+          {
+            text: "J. M. Wigstone"
+          },
+          {
+            html: '<a class="govuk-link" href="appeal-details?status=open&appealCode=0166321&site-address=2%20Aubrey%20House%2C%20Aubrey%20Road%2C%20BS3%203EX&appellantName=J.%20M.%20Wigstone&appealReference=0166321">0166321</a>',
+            format: "numeric"
+          }
+        ]
+      ]
+    }) }}
+
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+
+    <h2 class="govuk-heading-m">
+      Closed for comments
+    </h2>
+
+    <p class="govuk-body">
+      The deadline to comment on these appeals has passed. The Inspector will make a decision soon.
+    </p>
+
+  </div>
+
+  <!-- main table -->
+  <div class="govuk-grid-column-full">
+
+    {{ govukTable({
+      caption: "Open appeals",
+      captionClasses: "govuk-table__caption--m govuk-visually-hidden",
+
+      head: [
+
+      {
+        text: "Appeal site",
+        classes: 'govuk-!-width-one-half'
+      },
+      {
+        text: "Applicant",
+        classes: 'govuk-!-width-one-quarter'
+      },
+      {
+        text: "Appeal reference",
+        classes: 'govuk-!-width-one-quarter',
+        format: "numeric"
+      }
+      ],
+      rows: [
+        [
+          {
+            text: "103 Aubrey Road, Bristol BS3 3EX"
+          },
+          {
+            text: "Mel Pickins"
+          },
+          {
+            html: '<a class="govuk-link" href="appeal-details?status=closed&appealCode=0166327&site-address=103%20Aubrey%20Road%2C%20BS3%203EX&appellantName=Mel%20Pickins&appealReference=0166327">0166327</a>',
+            format: "numeric"
+          }
+        ],
+        [
+          {
+            text: "103 Aubrey Road, Bristol BS3 3EX"
+          },
+          {
+            text: "Mel Pickins"
+          },
+          {
+            html: '<a class="govuk-link" href="appeal-details?status=closed&appealCode=0166328&site-address=103%20Aubrey%20Road%2C%20BS3%203EX&appellantName=Mel%20Pickins&appealReference=0166328">0166328</a>',
+            format: "numeric"
+          }
+        ]
+      ]
+    }) }}
+
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+
+    <!-- <h2 class="govuk-visually-hidden"> -->
+    <h2 class="govuk-heading-m">
+      Completed appeals
+    </h2>
+
+    <p class="govuk-body">
+      If you cannot find the appeal you're looking for, it might be complete and a decision made.
+    </p>
+
+    <p>
+      <a href="closed-appeals" class="govuk-link">
+        {% if data['postcode'] %}
+          View 33 completed appeals for {{ data['postcode'] }}
+        {% else %}
+          View 33 completed appeals for BS3 3EX
+        {% endif %}
+      </a>
+    </p>
+
+  </div>
+
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -111,9 +111,18 @@
 
     {% set commentHTML %}
       <h2 class="govuk-heading-m">
-        Find and comment on an appeal
+        Interested parties
       </h2>
-      <p>Coming soon…</p>
+
+      <!-- <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+        Find an appeal
+      </h3> -->
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <a href="appeal/find-appeal/">Find and comment on an appeal</a>
+        </li>
+      </ul>  
+
     {% endset -%}
 
     {{ govukTabs({

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -119,9 +119,9 @@
       </h3> -->
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="appeal/find-appeal/">Find and comment on an appeal</a>
+          <a href="appeal/find-appeal/">Find and comment on an appeal (design work in progress from May 2022)</a>
         </li>
-      </ul>  
+      </ul>
 
     {% endset -%}
 

--- a/app/views/manage/final-comments/v1/add-comments.html
+++ b/app/views/manage/final-comments/v1/add-comments.html
@@ -95,34 +95,7 @@
 
         <p>You must not include any sensitive information in your comments.</p>
 
-        {% set sensitiveHTML %}
-          <p class="govuk-!-margin-bottom-2">Sensitive information refers to:</p>
-          <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-            <li>comments from children</li>
-            <li>information relating to children</li>
-            <li>information relating to health</li>
-            <li>information relating to crime</li>
-            <li>
-              any information relating to an individual&rsquo;s:
-              <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-                <li>race</li>
-                <li>ethnic origin</li>
-                <li>politics</li>
-                <li>religion</li>
-                <li>trade union membership</li>
-                <li>genetics</li>
-                <li>physical characteristics</li>
-                <li>sex life</li>
-                <li>sexual orientation</li>
-              </ul>
-            </li>
-          </ul>
-        {% endset -%}
-
-        {{ govukDetails({
-          summaryHtml: 'What is sensitive information?',
-          html: sensitiveHTML
-        }) }}
+        {% include "_includes/sensitive-information-list.html" %}
 
         {{ govukTextarea({
           name: 'final-comments',

--- a/app/views/manage/statement/v1/enter-statement.html
+++ b/app/views/manage/statement/v1/enter-statement.html
@@ -30,7 +30,7 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
 
     {# Tweak the summary list to be smaller #}
     <style>
@@ -74,6 +74,11 @@
         }
       ]
     }) }}
+  </div>
+  </div>
+
+  <div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
   <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 


### PR DESCRIPTION
Previous design work in progress from May 2022, moved to the new prototype for reference / basis.

1. Moved work here
2. Updated tag colours to align more with GDS tag colours

We need to update some of the patterns here (enter comments / upload documents).

The prototype was well understood and easy to use in research but there were some questions left unanswered:
- how can the interested party see details of the appeal?
- how can we get the link to the application? if we can surface the appeal details, do we need to?