### PR TITLE
Tiny fix for appeal ref

### DIFF
--- a/app/views/interested/find-appeal/v5/appeal-details.html
+++ b/app/views/interested/find-appeal/v5/appeal-details.html
@@ -100,7 +100,7 @@
             Appeal reference
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ data['appealCode'] }}
+            {{ data['appealCode'] or '0166327' }}
           </dd>
         </div>
 


### PR DESCRIPTION
Rolling back the last commit which accidentally pulled in old work.

Also fix to presentation of the appeal reference on the appeal details screen.